### PR TITLE
Adding icon so chart passes `helm lint`

### DIFF
--- a/helm/botkube/Chart.yaml
+++ b/helm/botkube/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: botkube
+icon: https://www.botkube.io/images/botkube.ico
 version: 0.1.0


### PR DESCRIPTION
Helm lint recommends that charts include an icon. I added one that was already hosted on the website

## Helm Lint Output Before Change
```
➜  botkube git:(master) ✗ helm lint .
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, no failures
```

## Helm Lint Output After Change
```
➜  botkube git:(master) ✗ cat Chart.yaml 
apiVersion: v1
appVersion: "1.0"
description: A Helm chart for Kubernetes
icon: https://www.botkube.io/images/botkube.ico
name: botkube
version: 0.1.0


➜  botkube git:(master) ✗ helm lint .
==> Linting .
Lint OK

1 chart(s) linted, no failures
```

