### PR TITLE
Add badges for Slack and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BotKube
-[![Build Status](https://travis-ci.org/infracloudio/botkube.svg?branch=master)](https://travis-ci.org/infracloudio/botkube) [![Go Report Card](https://goreportcard.com/badge/github.com/infracloudio/botkube)](https://goreportcard.com/report/github.com/infracloudio/botkube)
+[![Build Status](https://travis-ci.org/infracloudio/botkube.svg?branch=master)](https://travis-ci.org/infracloudio/botkube) [![Go Report Card](https://goreportcard.com/badge/github.com/infracloudio/botkube)](https://goreportcard.com/report/github.com/infracloudio/botkube) [![BotKube website](https://img.shields.io/badge/docs-botkube.io-blue.svg)](https://botkube.io) [![Slack](https://botkube-slack.herokuapp.com/badge.svg)](http://join.botkube.io/)
 
 For complete documentation visit www.botkube.io
 


### PR DESCRIPTION
- This makes is really easy to find the website as well as Slack when
  someone visits the repository
