### PR TITLE
Add GitHub Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+##### ISSUE TYPE
+<!--- Pick one below and delete the rest: -->
+ - Feature Pull Request
+ - Bug fix Pull Request
+ - Docs Pull Request
+
+##### SUMMARY
+<!--- Describe the change, including rationale and design decisions -->
+
+<!---
+If you are fixing an existing issue, please include "Fixes #nnn" in your
+PR comment; and describe briefly what the change does.
+-->
+
+<!--- Please list dependencies added with your change also -->
+
+Fixes #XXX


### PR DESCRIPTION
- Makes it easy for contributors to create a new PR
- It will ensure that the issue being solved by PR gets referenced in
   the Pull Request body
- Taken from
  https://github.com/transtats/transtats/blob/devel/.github/PULL_REQUEST_TEMPLATE.md
  which is Apache 2.0 licensed

