### PR TITLE
feature set command

### DIFF
--- a/helm/botkube/templates/clusterrole.yaml
+++ b/helm/botkube/templates/clusterrole.yaml
@@ -10,4 +10,4 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
-    verbs: ["get", "watch", "list"]
+    verbs: ["get", "watch", "list", "patch"]

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -25,6 +25,7 @@ var validKubectlCommands = map[string]bool{
 	"logs":          true,
 	"top":           true,
 	"auth":          true,
+	"set":           true,
 }
 
 var validNotifierCommand = map[string]bool{
@@ -161,6 +162,12 @@ func runKubectlCommand(args []string, clusterName string, isAuthChannel bool) st
 		}
 		if arg == AbbrWatchFlag.String() || strings.HasPrefix(arg, WatchFlag.String()) {
 			continue
+		}
+		// Parse set image case
+		if strings.Contains(arg, "<http://") && strings.Contains(arg, "=") && strings.Contains(arg, "|") {
+			fullImageArgs := strings.SplitN(arg, "=", 2)
+			imageArgs := strings.SplitN(fullImageArgs[1], "|", 2)
+			arg = fullImageArgs[0] + "=" + strings.TrimRight(imageArgs[1], ">")
 		}
 		// Check --cluster-name flag
 		if strings.HasPrefix(arg, ClusterFlag.String()) {


### PR DESCRIPTION
Hi

I add "set" command botkube.
because for using ChatOps Pipeline with botkube.

![スクリーンショット 2019-04-16 18 32 42](https://user-images.githubusercontent.com/17565502/56198692-59c4fc00-6076-11e9-8544-aef10e25a344.png)

this PR, fix parse slack url encording in pkg/execute/executor.go 
because, container image url, example `set image deployment nginx-svc nginx=gcr.io/hoge/hello-world-container`, 
slack print `set image deployment nginx-svc nginx=<https://gcr.io/hoge/hello-world-container|gcr.io/hoge/hello-world-container>` and sending to botkube.