### PR TITLE
Add support to manage filters with @BotKube command

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -14,6 +14,8 @@ import (
 	"github.com/infracloudio/botkube/pkg/config"
 	"github.com/infracloudio/botkube/pkg/events"
 	"github.com/infracloudio/botkube/pkg/filterengine"
+	// Register filters
+	_ "github.com/infracloudio/botkube/pkg/filterengine/filters"
 	log "github.com/infracloudio/botkube/pkg/logging"
 	"github.com/infracloudio/botkube/pkg/notify"
 	"github.com/infracloudio/botkube/pkg/utils"

--- a/pkg/filterengine/filterengine.go
+++ b/pkg/filterengine/filterengine.go
@@ -1,32 +1,28 @@
 package filterengine
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/infracloudio/botkube/pkg/events"
-	"github.com/infracloudio/botkube/pkg/filterengine/filters"
 	log "github.com/infracloudio/botkube/pkg/logging"
 )
 
 var (
 	// DefaultFilterEngine contains default implementation for FilterEngine
 	DefaultFilterEngine FilterEngine
-
-	// Filters contains the lists of available filters
-	// TODO: load this dynamically
-	Filters = []Filter{
-		filters.NewImageTagChecker(),
-		filters.NewIngressValidator(),
-		filters.NewPodLabelChecker(),
-	}
 )
 
 // FilterEngine has methods to register and run filters
 type FilterEngine interface {
 	Run(interface{}, events.Event) events.Event
 	Register(Filter)
+	ShowFilters() map[string]bool
+	SetFilter(string, bool) error
 }
 
 type defaultFilters struct {
-	FiltersList []Filter
+	FiltersMap map[Filter]bool
 }
 
 // Filter has method to run filter
@@ -36,29 +32,52 @@ type Filter interface {
 
 func init() {
 	DefaultFilterEngine = NewDefaultFilter()
-
-	// Register filters
-	for _, f := range Filters {
-		DefaultFilterEngine.Register(f)
-	}
 }
 
 // NewDefaultFilter creates new DefaultFilter object
 func NewDefaultFilter() FilterEngine {
-	return &defaultFilters{}
+	var df defaultFilters
+	df.FiltersMap = make(map[Filter]bool)
+	return &df
 }
 
 // Run run the filters
 func (f *defaultFilters) Run(object interface{}, event events.Event) events.Event {
 	log.Logger.Debug("Filterengine running filters")
-	for _, f := range f.FiltersList {
-		f.Run(object, &event)
+	// Run registered filters
+	for k, v := range f.FiltersMap {
+		if v {
+			k.Run(object, &event)
+		}
 	}
 	return event
 }
 
 // Register filter to engine
 func (f *defaultFilters) Register(filter Filter) {
-	log.Logger.Debug("Registering the filter", filter)
-	f.FiltersList = append(f.FiltersList, filter)
+	log.Logger.Info("Registering the filter ", reflect.TypeOf(filter).Name())
+	f.FiltersMap[filter] = true
+}
+
+// ShowFilters return map of filter name and status
+func (f defaultFilters) ShowFilters() map[string]bool {
+	fmap := make(map[string]bool)
+
+	// Find filter struct name and set map
+	for k, v := range f.FiltersMap {
+		fmap[reflect.TypeOf(k).Name()] = v
+	}
+	return fmap
+}
+
+// SetFilter sets filter value in FilterMap to enable or disable filter
+func (f *defaultFilters) SetFilter(name string, flag bool) error {
+	// Find filter struct name
+	for k := range f.FiltersMap {
+		if reflect.TypeOf(k).Name() == name {
+			f.FiltersMap[k] = flag
+			return nil
+		}
+	}
+	return fmt.Errorf("Invalid filter name %s", name)
 }

--- a/pkg/filterengine/filters/image_tag_checker.go
+++ b/pkg/filterengine/filters/image_tag_checker.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/infracloudio/botkube/pkg/events"
+	"github.com/infracloudio/botkube/pkg/filterengine"
 	log "github.com/infracloudio/botkube/pkg/logging"
 
 	apiV1 "k8s.io/api/core/v1"
@@ -13,13 +14,13 @@ import (
 type ImageTagChecker struct {
 }
 
-// NewImageTagChecker creates new ImageTagChecker object
-func NewImageTagChecker() *ImageTagChecker {
-	return &ImageTagChecker{}
+// Register filter
+func init() {
+	filterengine.DefaultFilterEngine.Register(ImageTagChecker{})
 }
 
 // Run filers and modifies event struct
-func (f *ImageTagChecker) Run(object interface{}, event *events.Event) {
+func (f ImageTagChecker) Run(object interface{}, event *events.Event) {
 	if event.Kind != "Pod" && event.Type != "create" {
 		return
 	}

--- a/pkg/filterengine/filters/ingress_validator.go
+++ b/pkg/filterengine/filters/ingress_validator.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"github.com/infracloudio/botkube/pkg/events"
+	"github.com/infracloudio/botkube/pkg/filterengine"
 	extV1beta1 "k8s.io/api/extensions/v1beta1"
 )
 
@@ -10,13 +11,13 @@ import (
 type IngressValidator struct {
 }
 
-// NewIngressValidator returns new IngressValidator object
-func NewIngressValidator() *IngressValidator {
-	return &IngressValidator{}
+// Register filter
+func init() {
+	filterengine.DefaultFilterEngine.Register(IngressValidator{})
 }
 
 // Run filers and modifies event struct
-func (iv *IngressValidator) Run(object interface{}, event *events.Event) {
+func (iv IngressValidator) Run(object interface{}, event *events.Event) {
 	if event.Kind != "Ingress" && event.Type != "create" {
 		return
 	}

--- a/pkg/filterengine/filters/pod_label_checker.go
+++ b/pkg/filterengine/filters/pod_label_checker.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"github.com/infracloudio/botkube/pkg/events"
+	"github.com/infracloudio/botkube/pkg/filterengine"
 	log "github.com/infracloudio/botkube/pkg/logging"
 
 	apiV1 "k8s.io/api/core/v1"
@@ -11,13 +12,13 @@ import (
 type PodLabelChecker struct {
 }
 
-// NewPodLabelChecker creates new PodLabelChecker object
-func NewPodLabelChecker() *PodLabelChecker {
-	return &PodLabelChecker{}
+// Register filter
+func init() {
+	filterengine.DefaultFilterEngine.Register(PodLabelChecker{})
 }
 
 // Run filters and modifies event struct
-func (f *PodLabelChecker) Run(object interface{}, event *events.Event) {
+func (f PodLabelChecker) Run(object interface{}, event *events.Event) {
 	if event.Kind != "Pod" && event.Type != "create" {
 		return
 	}


### PR DESCRIPTION
fixes #71 

Usage:
```
@BotKube filters list : list all filters
@Botkube filters disable <filter-name> : Disable perticular filter
@Botkube filters enable <filter-name> : Enable a filter
```
Next action items:
- Update steps to create custom filter in botkube-docs
- Update BotKube help with filter command documentation