### PR TITLE
[helm chart] make image tag configurable

### DIFF
--- a/helm/botkube/Chart.yaml
+++ b/helm/botkube/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 name: botkube
 home: https://www.botkube.io
 version: 0.7.0
+appVersion: 0.7.0
 icon: https://www.botkube.io/images/botkube.ico
 description: Controller for the BotKube Slack app which helps you monitor your Kubernetes cluster,
  debug deployments and run specific checks on resources in the cluster.

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: {{ include "botkube.fullname" . }}-sa
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: config-volume

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -7,6 +7,9 @@ replicaCount: 1
 image:
   repository: infracloud/botkube
   pullPolicy: Always
+  ## default tag is appVersion from Chart.yaml. If you want to use
+  ## some other tag then it can be specified here
+  # tag: latest
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
- If image.tag is set in values.yaml then that tag is used, otherwise
  falls back to Chart version
- This makes easy to deploy images tagged with different names which
  are not according to sem ver 2 i.e. 'latest' or other valid
  container image tags

fixes #88 