### PR TITLE
[Travis CI] don't push container image for PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - make 
 
 after_success:
-  - if [[ "$TRAVIS_BRANCH" == "develop" ]]; then
+  - if [[ "$TRAVIS_BRANCH" == "develop" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
       docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
       docker push infracloud/botkube:latest;
     fi


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
- Makes sure that image on Docker hub is updated only for commits to
  develop branch and not for PRs
- ref:
  https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions
- As PRs from contributors don't have access to secrets, builds are failing with error like this one, https://travis-ci.org/infracloudio/botkube/builds/533893897#L580