### PR TITLE
Add JobStatusChecker filter and fix timestamp for error events

### DIFF
--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -103,6 +103,7 @@ config:
       events:
         - create
         - delete
+        - update
         - error
     - name: roles
       namespaces:

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -100,6 +100,7 @@ func New(object interface{}, eventType config.EventType, kind string) Event {
 		event.Level = LevelMap[config.EventType(strings.ToLower(obj.Type))]
 		event.Count = obj.Count
 		event.Action = obj.Action
+		event.TimeStamp = obj.LastTimestamp.Time
 	case *apiV1.Pod:
 		event.Kind = "Pod"
 	case *apiV1.Node:

--- a/pkg/filterengine/filters/job_status_checker.go
+++ b/pkg/filterengine/filters/job_status_checker.go
@@ -34,7 +34,7 @@ func (f JobStatusChecker) Run(object interface{}, event *events.Event) {
 
 	// Check latest job conditions
 	jobLen := len(jobObj.Status.Conditions)
-	if jobLen < 1 {
+	if jobLen == 0 {
 		event.Skip = true
 		return
 	}

--- a/pkg/filterengine/filters/job_status_checker.go
+++ b/pkg/filterengine/filters/job_status_checker.go
@@ -1,0 +1,51 @@
+// JobStatusChecker filter to send notifications only when job succeeds
+// and ignore other update events
+
+package filters
+
+import (
+	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/events"
+	"github.com/infracloudio/botkube/pkg/filterengine"
+	log "github.com/infracloudio/botkube/pkg/logging"
+
+	batchV1 "k8s.io/api/batch/v1"
+)
+
+// JobStatusChecker checks job status and adds message in the events structure
+type JobStatusChecker struct {
+}
+
+// Register filter
+func init() {
+	filterengine.DefaultFilterEngine.Register(JobStatusChecker{})
+}
+
+// Run filers and modifies event struct
+func (f JobStatusChecker) Run(object interface{}, event *events.Event) {
+	// Run filter only on Job update event
+	if event.Kind != "Job" && event.Type != config.UpdateEvent {
+		return
+	}
+	jobObj, ok := object.(*batchV1.Job)
+	if !ok {
+		return
+	}
+
+	// Check latest job conditions
+	jobLen := len(jobObj.Status.Conditions)
+	if jobLen < 1 {
+		event.Skip = true
+		return
+	}
+	c := jobObj.Status.Conditions[jobLen-1]
+	if c.Type == batchV1.JobComplete {
+		event.Messages = []string{"Job succeeded!"}
+		event.TimeStamp = c.LastTransitionTime.Time
+	} else {
+		event.Skip = true
+		return
+	}
+	event.Reason = c.Reason
+	log.Logger.Debug("Job status checker filter successful!")
+}


### PR DESCRIPTION
##### SUMMARY
- Add JobStatusChecker filter to send Job success notifications when configured to watch update events
- Add missing TimeStamps in error events

Fixes #95 and #107 

##### SCREENSHOTS
BotKube configuration for `jobs`:
```
    - name: jobs
      namespaces:
        - all
      events:
        - delete
        - update
        - error
```

1. Job success notification
![image](https://user-images.githubusercontent.com/7098659/60012870-a9d5c580-969a-11e9-9582-785213ebfacc.png)


2. Job Failure notification
![image](https://user-images.githubusercontent.com/7098659/60012887-b35f2d80-969a-11e9-8413-e9b6fb01830f.png)


3. Error events
![image](https://user-images.githubusercontent.com/7098659/60012901-bce89580-969a-11e9-991e-16f98d371451.png)
