### PR TITLE
Fix make target in travis CI to build image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - helm lint helm/botkube
 
 script:
-  - make 
+  - make container-image
 
 after_success:
   - if [[ "$TRAVIS_BRANCH" == "develop" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then


### PR DESCRIPTION
##### SUMMARY
Currently, travis CI build seems to be broken. Since we have changed make target to build a container image, need to update travis CI script accordingly.

From travis job log (https://travis-ci.org/infracloudio/botkube/builds/550685578):
```
$ if [[ "$TRAVIS_BRANCH" == "develop" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; docker push infracloud/botkube:latest; fi
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
The push refers to a repository [docker.io/infracloud/botkube]
An image does not exist locally with the tag: infracloud/botkube
```