### PR TITLE
Patch/delete double whitespace

### DIFF
--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -3,7 +3,6 @@ package execute
 import (
 	"bytes"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -13,9 +12,12 @@ import (
 	"text/tabwriter"
 	"unicode"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/infracloudio/botkube/pkg/config"
 	filterengine "github.com/infracloudio/botkube/pkg/filterengine"
 	log "github.com/infracloudio/botkube/pkg/logging"
+	"github.com/infracloudio/botkube/pkg/utils"
 )
 
 var validKubectlCommands = map[string]bool{
@@ -178,7 +180,7 @@ func trimQuotes(clusterValue string) string {
 
 func runKubectlCommand(args []string, clusterName string, isAuthChannel bool) string {
 	// Use 'default' as a default namespace
-	args = append([]string{"-n", "default"}, args...)
+	args = append([]string{"-n", "default"}, utils.DeleteDoubleWhiteSpace(args)...)
 
 	// Remove unnecessary flags
 	finalArgs := []string{}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -225,3 +225,14 @@ func GetObjectTypeMetaData(obj interface{}) metaV1.TypeMeta {
 	}
 	return typeMeta
 }
+
+// DeleteDoubleWhiteSpace returns slice that removing whitespace from a arg slice
+func DeleteDoubleWhiteSpace(slice []string) []string {
+	result := []string{}
+	for _, s := range slice {
+		if s != " " {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -230,7 +230,7 @@ func GetObjectTypeMetaData(obj interface{}) metaV1.TypeMeta {
 func DeleteDoubleWhiteSpace(slice []string) []string {
 	result := []string{}
 	for _, s := range slice {
-		if s != " " {
+		if len(s) != 0 {
 			result = append(result, s)
 		}
 	}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
botkube receive command, include not one whitespace, butwork.
for example, 「@botkube get  node」("@botkube" " " "get" " " " " "node" )

I think, botkube sould convert one or more spaces into one space

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->