### PR TITLE
Add flag to control Config Watcher

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -162,5 +162,7 @@ settings:
   clustername: not-configured
   # Set true to enable kubectl commands execution
   allowkubectl: false
+  # Set true to enable config watcher
+  configwatcher: true
   # Set false to disable upgrade notification
   upgradeNotifier: true

--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -172,6 +172,8 @@ data:
       clustername: not-configured
       # Set true to enable kubectl commands execution
       allowkubectl: false
+      # Set true to enable config watcher
+      configwatcher: true
       # Set false to disable upgrade notification
       upgradeNotifier: true
 ---

--- a/deploy-all-in-one.yaml
+++ b/deploy-all-in-one.yaml
@@ -172,6 +172,8 @@ data:
       clustername: not-configured
       # Set true to enable kubectl commands execution
       allowkubectl: false
+      # Set true to enable config watcher
+      configwatcher: true
       # Set false to disable upgrade notification
       upgradeNotifier: true
 ---

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -183,6 +183,8 @@ config:
     clustername: not-configured
     # Set true to enable kubectl commands execution
     allowkubectl: false
+    # Set true to enable config watcher
+    configwatcher: true
     # Set false to disable upgrade notification
     upgradeNotifier: true
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,6 +103,7 @@ type Mattermost struct {
 type Settings struct {
 	ClusterName     string
 	AllowKubectl    bool
+	ConfigWatcher   bool
 	UpgradeNotifier bool `yaml:"upgradeNotifier"`
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -37,8 +37,10 @@ func RegisterInformers(c *config.Config) {
 	sendMessage(c, fmt.Sprintf(controllerStartMsg, c.Settings.ClusterName))
 	startTime = time.Now()
 
-	// Start config file watcher
-	go configWatcher(c)
+	// Start config file watcher if enabled
+	if c.Settings.ConfigWatcher {
+		go configWatcher(c)
+	}
 
 	// Register informers for resource lifecycle events
 	if len(c.Resources) > 0 {


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This commit,
- adds `config.settings.configwatcher` to enable/disable config watcher
- updates info in all config.yaml files
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

Fixes #150 


