### PR TITLE
Node Level Critical Events filter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,9 +9,6 @@ import (
 )
 
 const (
-	// AllowedEventType K8s event types allowed to forward
-	AllowedEventType EventType = WarningEvent
-
 	// CreateEvent when resource is created
 	CreateEvent EventType = "create"
 	// UpdateEvent when resource is updated
@@ -22,6 +19,10 @@ const (
 	ErrorEvent EventType = "error"
 	// WarningEvent for warning events
 	WarningEvent EventType = "warning"
+	// NormalEvent for Normal events
+	NormalEvent EventType = "normal"
+	// InfoEvent for insignificant Info events
+	InfoEvent EventType = "info"
 	// AllEvent to watch all events
 	AllEvent EventType = "all"
 	// ShortNotify is the Default NotifType

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -93,7 +93,13 @@ func New(object interface{}, eventType config.EventType, kind string) Event {
 	}
 
 	if kind != "events" {
-		event.Messages = []string{fmt.Sprintf("Resource %sd\n", eventType.String())}
+		switch eventType {
+		case config.ErrorEvent, config.InfoEvent:
+			event.Messages = []string{fmt.Sprintf("Resource %s\n", eventType.String())}
+		default:
+			// Events like create, update, delete comes with an extra 'd' at the end
+			event.Messages = []string{fmt.Sprintf("Resource %sd\n", eventType.String())}
+		}
 	}
 
 	switch obj := object.(type) {

--- a/pkg/filterengine/filters/node_event_checker.go
+++ b/pkg/filterengine/filters/node_event_checker.go
@@ -1,0 +1,67 @@
+// NodeEventsChecker filter to send notifications on critical node events
+
+package filters
+
+import (
+	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/events"
+	"github.com/infracloudio/botkube/pkg/filterengine"
+	apiV1 "k8s.io/api/core/v1"
+
+	log "github.com/infracloudio/botkube/pkg/logging"
+)
+
+const (
+	// NodeNotReady EventReason when Node is NotReady
+	NodeNotReady string = "NodeNotReady"
+	// NodeReady EventReason when Node is Ready
+	NodeReady string = "NodeReady"
+)
+
+// NodeEventsChecker checks job status and adds message in the events structure
+type NodeEventsChecker struct {
+	Description string
+}
+
+// Register filter
+func init() {
+	filterengine.DefaultFilterEngine.Register(NodeEventsChecker{
+		Description: "Sends notifications on node level critical events.",
+	})
+}
+
+// Run filers and modifies event struct
+func (f NodeEventsChecker) Run(object interface{}, event *events.Event) {
+
+	// Check for Event object
+	_, ok := object.(*apiV1.Event)
+	if !ok {
+		return
+	}
+
+	// Run filter only on Node events
+	if event.Kind != "Node" {
+		return
+	}
+
+	// Update event details
+	// Promote InfoEvent with critical reason as significant ErrorEvent
+	switch event.Reason {
+	case NodeNotReady:
+		event.Type = config.ErrorEvent
+		event.Level = events.Critical
+	case NodeReady:
+		event.Type = config.ErrorEvent
+		event.Level = events.Info
+	default:
+		// skip events with least significant reasons
+		event.Skip = true
+	}
+
+	log.Logger.Debug("Node Critical Event filter successful!")
+}
+
+// Describe filter
+func (f NodeEventsChecker) Describe() string {
+	return f.Description
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR,
- Allows  kubernetes events of `Warning` Type as `ErrorEvents`
- Allows kubernetes events of `Normal` Type as Insignificant `InfoEvents`
- Adds `NodeEventsChecker` filter to check for Node InfoEvents with critical reasons like `NodeNotReady` ,`NodeReady`.
- `InfoEvents` with critical reasons are promoted as significant Node `ErrorEvents`
- Post events filtering, unpromoted Insignificant `InfoEvents` are skipped. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

Fixes #134

**Preview**
![node-event-filter](https://user-images.githubusercontent.com/30741615/63226992-36b28080-c1ff-11e9-8119-b68921429504.png)

