### PR TITLE
Add support for Webhooks

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -43,7 +43,9 @@ func main() {
 	if Config.Communications.ElasticSearch.Enabled {
 		notifiers = append(notifiers, notify.NewElasticSearch(Config))
 	}
-
+	if Config.Communications.Webhook.Enabled {
+		notifiers = append(notifiers, notify.NewWebhook(Config))
+	}
 	if Config.Settings.UpgradeNotifier {
 		log.Logger.Info("Starting upgrade notifier")
 		go controller.UpgradeNotifier(Config, notifiers)

--- a/config.yaml
+++ b/config.yaml
@@ -210,6 +210,11 @@ communications:
       shards: 1
       replicas: 0
 
+  # Settings for Webhook
+  webhook:
+    enabled: false
+    url: 'WEBHOOK_URL'              # e.g https://example.com:80
+
 # Setting to support multiple clusters
 settings:
   # Cluster name to differentiate incoming messages

--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -215,6 +215,12 @@ data:
           type: botkube-event
           shards: 1
           replicas: 0
+      
+      # Settings for Webhook
+      webhook:
+        enabled: false
+        url: 'WEBHOOK_URL'                          # e.g https://example.com:80
+
   
     # Setting to support multiple clusters
     settings:

--- a/deploy-all-in-one.yaml
+++ b/deploy-all-in-one.yaml
@@ -216,7 +216,12 @@ data:
           type: botkube-event
           shards: 1
           replicas: 0
-  
+      
+      # Settings for Webhook
+      webhook:
+        enabled: false
+        url: 'WEBHOOK_URL'                          # e.g https://example.com:80
+
     # Setting to support multiple clusters
     settings:
       # Cluster name to differentiate incoming messages

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -235,6 +235,12 @@ config:
         type: botkube-event
         shards: 1
         replicas: 0
+    
+    # Settings for Webhook
+    webhook:
+      enabled: false
+      url: 'WEBHOOK_URL'                          # e.g https://example.com:80
+
 
   # Setting to support multiple clusters
   settings:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,7 @@ type Communications struct {
 	Slack         Slack
 	ElasticSearch ElasticSearch
 	Mattermost    Mattermost
+	Webhook       Webhook
 }
 
 // Slack configuration to authentication and send notifications
@@ -109,6 +110,12 @@ type Mattermost struct {
 	Team      string
 	Channel   string
 	NotifType NotifType `yaml:",omitempty"`
+}
+
+// Webhook configuration to send notifications
+type Webhook struct {
+	Enabled bool
+	URL     string
 }
 
 // Settings for multicluster support

--- a/pkg/notify/webhook.go
+++ b/pkg/notify/webhook.go
@@ -1,0 +1,121 @@
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/events"
+	log "github.com/infracloudio/botkube/pkg/logging"
+)
+
+// Webhook contains URL and ClusterName
+type Webhook struct {
+	URL         string
+	ClusterName string
+}
+
+// WebhookPayload contains json payload to be sent to webhook url
+type WebhookPayload struct {
+	EventMeta       EventMeta   `json:"meta"`
+	EventStatus     EventStatus `json:"status"`
+	EventSummary    string      `json:"summary"`
+	TimeStamp       time.Time   `json:"timestamp"`
+	Recommendations []string    `json:"recommendations,omitempty"`
+	Warnings        []string    `json:"warnings,omitempty"`
+}
+
+// EventMeta contains the meta data about the event occurred
+type EventMeta struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Cluster   string `json:"cluster,omitempty"`
+}
+
+// EventStatus contains the status about the event occurred
+type EventStatus struct {
+	Type     config.EventType `json:"type"`
+	Level    events.Level     `json:"level"`
+	Reason   string           `json:"reason,omitempty"`
+	Error    string           `json:"error,omitempty"`
+	Messages []string         `json:"messages,omitempty"`
+}
+
+// NewWebhook returns new Webhook object
+func NewWebhook(c *config.Config) Notifier {
+	return &Webhook{
+		URL:         c.Communications.Webhook.URL,
+		ClusterName: c.Settings.ClusterName,
+	}
+}
+
+// SendEvent sends event notification to Webhook url
+func (w *Webhook) SendEvent(event events.Event) (err error) {
+
+	// set missing cluster name to event object
+	event.Cluster = w.ClusterName
+
+	jsonPayload := &WebhookPayload{
+		EventMeta: EventMeta{
+			Kind:      event.Kind,
+			Name:      event.Name,
+			Namespace: event.Namespace,
+			Cluster:   event.Cluster,
+		},
+		EventStatus: EventStatus{
+			Type:     event.Type,
+			Level:    event.Level,
+			Reason:   event.Reason,
+			Error:    event.Error,
+			Messages: event.Messages,
+		},
+		EventSummary:    event.Message(),
+		TimeStamp:       event.TimeStamp,
+		Recommendations: event.Recommendations,
+		Warnings:        event.Warnings,
+	}
+
+	err = w.PostWebhook(jsonPayload)
+	if err != nil {
+		log.Logger.Error(err.Error())
+		log.Logger.Debugf("Event Not Sent to Webhook %v", event)
+	}
+
+	log.Logger.Debugf("Event successfully sent to Webhook %v", event)
+	return nil
+}
+
+// SendMessage sends message to Webhook url
+func (w *Webhook) SendMessage(msg string) error {
+	return nil
+}
+
+// PostWebhook posts webhook to listener
+func (w *Webhook) PostWebhook(jsonPayload *WebhookPayload) error {
+
+	message, err := json.Marshal(jsonPayload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", w.URL, bytes.NewBuffer(message))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Error Posting Webhook: %s", string(resp.StatusCode))
+	}
+
+	return nil
+}

--- a/pkg/notify/webhook_test.go
+++ b/pkg/notify/webhook_test.go
@@ -1,0 +1,46 @@
+package notify
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Unit test PostWebhook
+func TestPostWebhook(t *testing.T) {
+	tests := map[string]struct {
+		server   *httptest.Server
+		expected error
+	}{
+		`Status Not Ok`: {
+			httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			})),
+			fmt.Errorf("Error Posting Webhook: %s", string(http.StatusServiceUnavailable)),
+		},
+		`Status Ok`: {
+			httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})),
+			nil,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			ts := test.server
+			defer ts.Close()
+			// create a dummy webhook object to test
+			w := &Webhook{
+				URL:         ts.URL,
+				ClusterName: "test",
+			}
+
+			err := w.PostWebhook(&WebhookPayload{})
+			assert.Equal(t, test.expected, err)
+		})
+	}
+}

--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -118,7 +118,7 @@ func (c *context) testNotifierCommand(t *testing.T) {
 		Kind:      "pod",
 		Namespace: "test",
 		Specs:     &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod-notifier"}},
-		Expected: utils.SlackMessage{
+		ExpectedSlackMessage: utils.SlackMessage{
 			Attachments: []slack.Attachment{{Color: "good", Fields: []slack.AttachmentField{{Title: "Pod create", Value: "Pod `test-pod` in of cluster `test-cluster-1`, namespace `test` has been created:\n```Resource created\nRecommendations:\n- pod 'test-pod' creation without labels should be avoided.\n```", Short: false}}, Footer: "BotKube"}},
 		},
 	}
@@ -135,7 +135,7 @@ func (c *context) testNotifierCommand(t *testing.T) {
 		err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 		assert.NoError(t, err, "message should decode properly")
 		assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
-		assert.NotEqual(t, pod.Expected.Attachments, m.Attachments)
+		assert.NotEqual(t, pod.ExpectedSlackMessage.Attachments, m.Attachments)
 	})
 
 	// Revert and Enable notifier

--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -13,7 +13,7 @@ import (
 	"github.com/infracloudio/botkube/test/e2e/utils"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -55,7 +55,7 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 
 			// Convert text message into Slack message structure
 			m := slack.Message{}
-			err := json.Unmarshal([]byte(lastSeenMsg), &m)
+			err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 			assert.NoError(t, err, "message should decode properly")
 			assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
 			switch test.command {
@@ -106,7 +106,7 @@ func (c *context) testNotifierCommand(t *testing.T) {
 
 		// Convert text message into Slack message structure
 		m := slack.Message{}
-		err := json.Unmarshal([]byte(lastSeenMsg), &m)
+		err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 		assert.NoError(t, err, "message should decode properly")
 		assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
 		assert.Equal(t, fmt.Sprintf("```Sure! I won't send you notifications from cluster '%s' anymore.```", c.Config.Settings.ClusterName), m.Text)
@@ -132,7 +132,7 @@ func (c *context) testNotifierCommand(t *testing.T) {
 
 		// Convert text message into Slack message structure
 		m := slack.Message{}
-		err := json.Unmarshal([]byte(lastSeenMsg), &m)
+		err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 		assert.NoError(t, err, "message should decode properly")
 		assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
 		assert.NotEqual(t, pod.Expected.Attachments, m.Attachments)
@@ -149,7 +149,7 @@ func (c *context) testNotifierCommand(t *testing.T) {
 
 		// Convert text message into Slack message structure
 		m := slack.Message{}
-		err := json.Unmarshal([]byte(lastSeenMsg), &m)
+		err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 		assert.NoError(t, err, "message should decode properly")
 		assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
 		assert.Equal(t, fmt.Sprintf("```Brace yourselves, notifications are coming from cluster '%s'.```", c.Config.Settings.ClusterName), m.Text)

--- a/test/e2e/command/kubectl.go
+++ b/test/e2e/command/kubectl.go
@@ -42,7 +42,7 @@ func (c *context) testKubectlCommand(t *testing.T) {
 
 			// Convert text message into Slack message structure
 			m := slack.Message{}
-			err := json.Unmarshal([]byte(lastSeenMsg), &m)
+			err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 			assert.NoError(t, err, "message should decode properly")
 			assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
 			assert.Equal(t, test.expected, m.Text)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,14 +22,27 @@ func TestRun(t *testing.T) {
 	testEnv := env.New()
 
 	// Fake notifiers
-	fakeSlackNotifier := &notify.Slack{
-		Token:       testEnv.Config.Communications.Slack.Token,
-		Channel:     testEnv.Config.Communications.Slack.Channel,
-		ClusterName: testEnv.Config.Settings.ClusterName,
-		NotifType:   testEnv.Config.Communications.Slack.NotifType,
-		SlackURL:    testEnv.SlackServer.GetAPIURL(),
+	notifiers := []notify.Notifier{}
+
+	if testEnv.Config.Communications.Slack.Enabled {
+		fakeSlackNotifier := &notify.Slack{
+			Token:       testEnv.Config.Communications.Slack.Token,
+			Channel:     testEnv.Config.Communications.Slack.Channel,
+			ClusterName: testEnv.Config.Settings.ClusterName,
+			NotifType:   testEnv.Config.Communications.Slack.NotifType,
+			SlackURL:    testEnv.SlackServer.GetAPIURL(),
+		}
+
+		notifiers = append(notifiers, fakeSlackNotifier)
 	}
-	notifiers := []notify.Notifier{fakeSlackNotifier}
+
+	if testEnv.Config.Communications.Webhook.Enabled {
+		fakeWebhookNotifier := &notify.Webhook{
+			URL:         testEnv.WebhookServer.GetAPIURL(),
+			ClusterName: testEnv.Config.Settings.ClusterName,
+		}
+		notifiers = append(notifiers, fakeWebhookNotifier)
+	}
 
 	utils.KubeClient = testEnv.K8sClient
 	utils.InitInformerMap()

--- a/test/e2e/env/env.go
+++ b/test/e2e/env/env.go
@@ -69,10 +69,13 @@ func (e *TestEnv) SetupFakeSlack() {
 }
 
 // GetLastSeenSlackMessage return last message received by fake slack server
-func (e TestEnv) GetLastSeenSlackMessage() string {
+func (e TestEnv) GetLastSeenSlackMessage() *string {
 	allSeenMessages := e.SlackServer.GetSeenOutboundMessages()
 	if len(allSeenMessages) != 0 {
-		return allSeenMessages[len(allSeenMessages)-1]
+		return &allSeenMessages[len(allSeenMessages)-1]
+	}
+	return nil
+}
 	}
 	return ""
 }

--- a/test/e2e/filters/filters.go
+++ b/test/e2e/filters/filters.go
@@ -9,7 +9,7 @@ import (
 	"github.com/infracloudio/botkube/test/e2e/utils"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extV1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -62,7 +62,7 @@ func (c *context) testFilters(t *testing.T) {
 
 			// Convert text message into Slack message structure
 			m := slack.Message{}
-			err := json.Unmarshal([]byte(lastSeenMsg), &m)
+			err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 			assert.NoError(t, err, "message should decode properly")
 			assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
 			assert.Equal(t, test.Expected.Attachments, m.Attachments)

--- a/test/e2e/notifier/create/create.go
+++ b/test/e2e/notifier/create/create.go
@@ -11,7 +11,7 @@ import (
 	testutils "github.com/infracloudio/botkube/test/e2e/utils"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,7 +52,7 @@ func (c *context) testCreateResource(t *testing.T) {
 
 			// Convert text message into Slack message structure
 			m := slack.Message{}
-			err := json.Unmarshal([]byte(lastSeenMsg), &m)
+			err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 			assert.NoError(t, err, "message should decode properly")
 			assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
 			assert.Equal(t, test.Expected.Attachments, m.Attachments)

--- a/test/e2e/notifier/create/create.go
+++ b/test/e2e/notifier/create/create.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/notify"
 	"github.com/infracloudio/botkube/pkg/utils"
 	"github.com/infracloudio/botkube/test/e2e/env"
 	testutils "github.com/infracloudio/botkube/test/e2e/utils"
@@ -27,16 +28,26 @@ func (c *context) testCreateResource(t *testing.T) {
 			Kind:      "pod",
 			Namespace: "test",
 			Specs:     &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}},
-			Expected: testutils.SlackMessage{
+			ExpectedSlackMessage: testutils.SlackMessage{
 				Attachments: []slack.Attachment{{Color: "good", Fields: []slack.AttachmentField{{Title: "Pod create", Value: "Pod `test-pod` in of cluster `test-cluster-1`, namespace `test` has been created:\n```Resource created\nRecommendations:\n- pod 'test-pod' creation without labels should be avoided.\n```", Short: false}}, Footer: "BotKube"}},
+			},
+			ExpectedWebhookPayload: testutils.WebhookPayload{
+				EventMeta:   notify.EventMeta{Kind: "Pod", Name: "test-pod", Namespace: "test", Cluster: "test-cluster-1"},
+				EventStatus: notify.EventStatus{Type: "create", Level: "info", Reason: "", Error: "", Messages: []string{"Resource created\n"}},
+				Summary:     "Pod `test-pod` in of cluster `test-cluster-1`, namespace `test` has been created:\n```Resource created\nRecommendations:\n- pod 'test-pod' creation without labels should be avoided.\n```",
 			},
 		},
 		"create service in configured namespace": {
 			Kind:      "service",
 			Namespace: "test",
 			Specs:     &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-service"}},
-			Expected: testutils.SlackMessage{
+			ExpectedSlackMessage: testutils.SlackMessage{
 				Attachments: []slack.Attachment{{Color: "good", Fields: []slack.AttachmentField{{Title: "Service create", Value: "Service `test-service` in of cluster `test-cluster-1`, namespace `test` has been created:\n```Resource created\n```", Short: false}}, Footer: "BotKube"}},
+			},
+			ExpectedWebhookPayload: testutils.WebhookPayload{
+				EventMeta:   notify.EventMeta{Kind: "Service", Name: "test-service", Namespace: "test", Cluster: "test-cluster-1"},
+				EventStatus: notify.EventStatus{Type: "create", Level: "info", Reason: "", Error: "", Messages: []string{"Resource created\n"}},
+				Summary:     "Service `test-service` in of cluster `test-cluster-1`, namespace `test` has been created:\n```Resource created\n```",
 			},
 		},
 	}
@@ -55,7 +66,14 @@ func (c *context) testCreateResource(t *testing.T) {
 			err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 			assert.NoError(t, err, "message should decode properly")
 			assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
-			assert.Equal(t, test.Expected.Attachments, m.Attachments)
+			assert.Equal(t, test.ExpectedSlackMessage.Attachments, m.Attachments)
+
+			// Get last seen webhook payload
+			lastSeenPayload := c.GetLastReceivedPayload()
+			assert.Equal(t, test.ExpectedWebhookPayload.EventMeta, lastSeenPayload.EventMeta)
+			assert.Equal(t, test.ExpectedWebhookPayload.EventStatus, lastSeenPayload.EventStatus)
+			assert.Equal(t, test.ExpectedWebhookPayload.Summary, lastSeenPayload.Summary)
+
 			isAllowed := utils.AllowedEventKindsMap[utils.EventKind{Resource: test.Kind, Namespace: "all", EventType: config.CreateEvent}] ||
 				utils.AllowedEventKindsMap[utils.EventKind{Resource: test.Kind, Namespace: test.Namespace, EventType: config.CreateEvent}]
 			assert.Equal(t, isAllowed, true)

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/infracloudio/botkube/pkg/config"
 	"github.com/infracloudio/botkube/pkg/utils"
 	"github.com/nlopes/slack"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extV1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/notify"
 	"github.com/infracloudio/botkube/pkg/utils"
 	"github.com/nlopes/slack"
 	v1 "k8s.io/api/core/v1"
@@ -17,13 +18,21 @@ type SlackMessage struct {
 	Attachments []slack.Attachment
 }
 
+// WebhookPayload structure
+type WebhookPayload struct {
+	Summary     string             `json:summary`
+	EventMeta   notify.EventMeta   `json:"meta"`
+	EventStatus notify.EventStatus `json:"status"`
+}
+
 // CreateObjects stores specs for creating a k8s fake object and expected Slack response
 type CreateObjects struct {
-	Kind      string
-	Namespace string
-	Specs     runtime.Object
-	NotifType config.NotifType
-	Expected  SlackMessage
+	Kind                   string
+	Namespace              string
+	Specs                  runtime.Object
+	NotifType              config.NotifType
+	ExpectedWebhookPayload WebhookPayload
+	ExpectedSlackMessage   SlackMessage
 }
 
 // CreateResource with fake client

--- a/test/e2e/welcome/welcome.go
+++ b/test/e2e/welcome/welcome.go
@@ -24,7 +24,7 @@ func (c *context) testWelcome(t *testing.T) {
 
 	// Convert text message into Slack message structure
 	m := slack.Message{}
-	err := json.Unmarshal([]byte(lastSeenMsg), &m)
+	err := json.Unmarshal([]byte(*lastSeenMsg), &m)
 	assert.NoError(t, err, "message should decode properly")
 	assert.Equal(t, c.Env.Config.Communications.Slack.Channel, m.Channel)
 	assert.Equal(t, expected, m.Text)

--- a/test/webhook/server.go
+++ b/test/webhook/server.go
@@ -1,0 +1,62 @@
+package webhook
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/infracloudio/botkube/test/e2e/utils"
+)
+
+// handle chat.postMessage
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+
+	decoder := json.NewDecoder(r.Body)
+
+	var t utils.WebhookPayload
+
+	err := decoder.Decode(&t)
+	if err != nil {
+		panic(err)
+	}
+
+	// update message in mutex
+	s.receivedPayloads.Lock()
+	s.receivedPayloads.messages = append(s.receivedPayloads.messages, t)
+	s.receivedPayloads.Unlock()
+
+}
+
+// NewTestServer returns a slacktest.Server ready to be started
+func NewTestServer() *Server {
+
+	s := &Server{
+		receivedPayloads: &payloadCollection{},
+	}
+	httpserver := httptest.NewUnstartedServer(s)
+	addr := httpserver.Listener.Addr().String()
+	s.ServerAddr = addr
+	s.server = httpserver
+	return s
+}
+
+// Start starts the test server
+func (s *Server) Start() {
+	log.Print("starting Mock Webhook server")
+	s.server.Start()
+}
+
+// GetAPIURL returns the api url you can pass to webhook
+func (s *Server) GetAPIURL() string {
+	return "http://" + s.ServerAddr + "/"
+}
+
+// GetReceivedPayloads returns all messages received
+func (s *Server) GetReceivedPayloads() []utils.WebhookPayload {
+	s.receivedPayloads.RLock()
+	m := s.receivedPayloads.messages
+	s.receivedPayloads.RUnlock()
+	return m
+}

--- a/test/webhook/types.go
+++ b/test/webhook/types.go
@@ -1,0 +1,21 @@
+package webhook
+
+import (
+	"net/http/httptest"
+	"sync"
+
+	"github.com/infracloudio/botkube/test/e2e/utils"
+)
+
+// payloadCollection mutex to hold incoming json payloads
+type payloadCollection struct {
+	sync.RWMutex
+	messages []utils.WebhookPayload
+}
+
+// Server represents a Webhook Test server
+type Server struct {
+	server           *httptest.Server
+	ServerAddr       string
+	receivedPayloads *payloadCollection
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
**Modify return type as pointer:**

This commit,
- modifies return type of  GetLastSeenSlackMessage to pointers.

**Add support for Webhooks:**

This Commit,
- Adds support for event notifications through `Wehbook` 
- updates configs in all yaml files
- updated helm charts
- adds unit tests for webhook notifier
- adds integration test webhook notifier
- adds test/webhook package to enable integration testing.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

**Preview**:

```
{
  "meta": {
    "kind": "Pod",
    "name": "command-app-1",
    "namespace": "default",
    "cluster": "demo"
  },
  "status": {
    "type": "create",
    "level": "info",
    "reason": "",
    "messages": [
      "Resource created\n"
    ]
  },
  "summary": "Pod `command-app-1` in of cluster `demo`, namespace `default` has been created:\n```Resource created\nRecommendations:\n- :latest tag used in image 'debian' of Container 'command-demo-container' should be avoided.\n```",
  "timestamp": "2019-08-30T22:29:04+05:30",
  "recommendations": [
    ":latest tag used in image 'debian' of Container 'command-demo-container' should be avoided.\n"
  ]
}
```