### PR TITLE
Add Support for MsTeams

### DIFF
--- a/cmd/botkube/main.go
+++ b/cmd/botkube/main.go
@@ -43,6 +43,9 @@ func main() {
 	if Config.Communications.ElasticSearch.Enabled {
 		notifiers = append(notifiers, notify.NewElasticSearch(Config))
 	}
+	if Config.Communications.MsTeams.Enabled {
+		notifiers = append(notifiers, notify.NewMsTeams(Config))
+	}
 	if Config.Communications.Webhook.Enabled {
 		notifiers = append(notifiers, notify.NewWebhook(Config))
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -210,6 +210,12 @@ communications:
       shards: 1
       replicas: 0
 
+  # Settings for MsTeams
+  msteams:
+    enabled: false
+    url: 'MSTEAMS_WEBHOOK_URL'                 # e.g https://example.com:80
+    notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
+
   # Settings for Webhook
   webhook:
     enabled: false

--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -215,6 +215,13 @@ data:
           type: botkube-event
           shards: 1
           replicas: 0
+
+      # Settings for MsTeams
+      msteams:
+        enabled: false
+        url: 'MSTEAMS_WEBHOOK_URL'                 # e.g https://example.com:80
+        notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
+
       
       # Settings for Webhook
       webhook:

--- a/deploy-all-in-one.yaml
+++ b/deploy-all-in-one.yaml
@@ -217,6 +217,13 @@ data:
           shards: 1
           replicas: 0
       
+      # Settings for MsTeams
+      msteams:
+        enabled: false
+        url: 'MSTEAMS_WEBHOOK_URL'                 # e.g https://example.com:80
+        notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
+  
+      
       # Settings for Webhook
       webhook:
         enabled: false

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -236,6 +236,12 @@ config:
         shards: 1
         replicas: 0
     
+    # Settings for MsTeams
+    msteams:
+      enabled: false
+      url: 'MSTEAMS_WEBHOOK_URL'                 # e.g https://example.com:80
+      notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
+    
     # Settings for Webhook
     webhook:
       enabled: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,7 @@ type Communications struct {
 	Slack         Slack
 	ElasticSearch ElasticSearch
 	Mattermost    Mattermost
+	MsTeams       MsTeams
 	Webhook       Webhook
 }
 
@@ -109,6 +110,13 @@ type Mattermost struct {
 	Token     string
 	Team      string
 	Channel   string
+	NotifType NotifType `yaml:",omitempty"`
+}
+
+// MsTeams configuration to send notifications
+type MsTeams struct {
+	Enabled   bool
+	URL       string
 	NotifType NotifType `yaml:",omitempty"`
 }
 

--- a/pkg/notify/msteams.go
+++ b/pkg/notify/msteams.go
@@ -1,0 +1,334 @@
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/events"
+	log "github.com/infracloudio/botkube/pkg/logging"
+)
+
+const (
+	// normal colour
+	normal string = "2DC72D"
+	// warning colour
+	warning string = "DEFF22"
+	// danger colour
+	danger string = "8C1A1A"
+
+	// Constants for sending  messageCards
+	messageType   = "MessageCard"
+	schemaContext = "http://schema.org/extensions"
+)
+
+var themeColor = map[events.Level]string{
+	events.Info:     normal,
+	events.Warn:     warning,
+	events.Debug:    normal,
+	events.Error:    danger,
+	events.Critical: danger,
+}
+
+// MsTeams contains msteams webhook url to send notification to
+type MsTeams struct {
+	URL         string
+	NotifType   config.NotifType
+	ClusterName string
+}
+
+// MessageCard is for the Card Fields to send in Teams
+type MessageCard struct {
+	Type       string    `json:"@type"`
+	Context    string    `json:"@context"`
+	ThemeColor string    `json:"themeColor"`
+	Summary    string    `json:"summary"`
+	Title      string    `json:"title,omitempty"`
+	Text       string    `json:"text,omitempty"`
+	Sections   []Section `json:"sections"`
+}
+
+// Section is placed under MessageCard.Sections
+type Section struct {
+	ActivityTitle string `json:"activitytitle"`
+	Facts         []Fact `json:"facts"`
+	Markdown      bool   `json:"markdown"`
+}
+
+// Fact is placed under Section.Fact
+type Fact struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// NewMsTeams returns new MsTeams object
+func NewMsTeams(c *config.Config) Notifier {
+	return &MsTeams{
+		URL:         c.Communications.MsTeams.URL,
+		NotifType:   c.Communications.MsTeams.NotifType,
+		ClusterName: c.Settings.ClusterName,
+	}
+}
+
+// SendEvent sends event notification to MsTeams
+func (m *MsTeams) SendEvent(event events.Event) error {
+
+	// set missing cluster name to event object
+	event.Cluster = m.ClusterName
+
+	card := &MessageCard{
+		Type:    messageType,
+		Context: schemaContext,
+		Title:   fmt.Sprintf("%s", event.Kind+" "+string(event.Type)),
+	}
+
+	card.Summary = card.GenerateTitle(event)
+
+	card.ThemeColor = themeColor[event.Level]
+
+	switch m.NotifType {
+	case config.LongNotify:
+
+		sectionFacts := []Fact{}
+
+		if event.Cluster != "" {
+			sectionFacts = append(sectionFacts, Fact{
+				Name:  "Cluster",
+				Value: event.Cluster,
+			})
+		}
+
+		sectionFacts = append(sectionFacts, Fact{
+			Name:  "Name",
+			Value: event.Name,
+		})
+
+		if event.Namespace != "" {
+			sectionFacts = append(sectionFacts, Fact{
+				Name:  "Namespace",
+				Value: event.Namespace,
+			})
+		}
+
+		if event.Reason != "" {
+			sectionFacts = append(sectionFacts, Fact{
+				Name:  "Reason",
+				Value: event.Reason,
+			})
+		}
+
+		if len(event.Messages) > 0 {
+			message := ""
+			for _, m := range event.Messages {
+				message = message + m + "\n"
+			}
+			sectionFacts = append(sectionFacts, Fact{
+				Name:  "Message",
+				Value: message,
+			})
+		}
+
+		if event.Action != "" {
+			sectionFacts = append(sectionFacts, Fact{
+				Name:  "Action",
+				Value: event.Action,
+			})
+		}
+
+		if len(event.Recommendations) > 0 {
+			rec := ""
+			for _, r := range event.Recommendations {
+				rec = rec + r + "\n"
+			}
+			sectionFacts = append(sectionFacts, Fact{
+				Name:  "Recommendations",
+				Value: rec,
+			})
+		}
+
+		if len(event.Warnings) > 0 {
+			warn := ""
+			for _, w := range event.Warnings {
+				warn = warn + w + "\n"
+			}
+			sectionFacts = append(sectionFacts, Fact{
+				Name:  "Warnings",
+				Value: warn,
+			})
+		}
+
+		card.Sections = append(card.Sections, Section{
+			Facts:    sectionFacts,
+			Markdown: true,
+		})
+
+	case config.ShortNotify:
+		fallthrough
+
+	default:
+		card.Sections = append(card.Sections, Section{
+			ActivityTitle: card.GenerateTitle(event),
+			Markdown:      true,
+		})
+
+		card.Sections = append(card.Sections, Section{
+			ActivityTitle: card.GenerateMessage(event),
+			Markdown:      true,
+		})
+	}
+
+	// post card to Msteam channel
+	if _, err := m.PostCard(card); err != nil {
+		log.Logger.Error(err.Error())
+		return err
+	}
+
+	log.Logger.Debugf("Event successfully sent to MS Teams >> %+v", event)
+	return nil
+}
+
+// SendMessage sends message to MsTeams
+func (m *MsTeams) SendMessage(msg string) error {
+
+	card := &MessageCard{
+		Type:    messageType,
+		Context: schemaContext,
+		Summary: msg,
+	}
+
+	card.ThemeColor = themeColor[events.Info]
+
+	card.Sections = append(card.Sections, Section{
+		ActivityTitle: msg,
+		Markdown:      true,
+	})
+
+	if _, err := m.PostCard(card); err != nil {
+		log.Logger.Error(err.Error())
+		return err
+	}
+
+	log.Logger.Debug("Message successfully sent to MS Teams")
+	return nil
+}
+
+// PostCard sends the JSON Encoded MessageCard to the msteams URL
+func (m *MsTeams) PostCard(card *MessageCard) (*http.Response, error) {
+
+	buffer := new(bytes.Buffer)
+
+	if err := json.NewEncoder(buffer).Encode(card); err != nil {
+		return nil, fmt.Errorf("Failed encoding message card: %v", err)
+	}
+
+	res, err := http.Post(m.URL, "application/json", buffer)
+	if err != nil {
+		return nil, fmt.Errorf("Failed sending to msteams url %s. Got the error: %v", m.URL, err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		resMessage, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, fmt.Errorf("Failed reading Teams http response: %v", err)
+		}
+		return nil, fmt.Errorf("Failed sending to the Teams Channel. Teams http response: %s, %s",
+			string(res.StatusCode), string(resMessage))
+	}
+
+	if err := res.Body.Close(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// GenerateMessage generates event messages to be sent with the card
+func (card *MessageCard) GenerateMessage(event events.Event) (message string) {
+
+	if len(event.Messages) > 0 {
+		for _, m := range event.Messages {
+			message = message + "> " + m + "\n"
+		}
+	}
+	if len(event.Recommendations) > 0 {
+		recommend := ""
+		for _, m := range event.Recommendations {
+			recommend = recommend + "\n- " + m
+		}
+		message = message + "\n" + "Recommendations:\n" + recommend
+	}
+	if len(event.Warnings) > 0 {
+		warning := ""
+		for _, m := range event.Warnings {
+			warning = warning + "\n- " + m
+		}
+		message = message + "\n" + "Warnings:\n" + warning
+	}
+	return message
+}
+
+// GenerateTitle generates message card title
+func (card *MessageCard) GenerateTitle(event events.Event) (title string) {
+
+	switch event.Type {
+	case config.CreateEvent, config.DeleteEvent, config.UpdateEvent:
+		switch event.Kind {
+		case "Namespace", "Node", "PersistentVolume", "ClusterRole", "ClusterRoleBinding":
+			title = fmt.Sprintf(
+				"%s `%s` in of cluster `%s` has been %s:",
+				event.Kind,
+				event.Name,
+				event.Cluster,
+				event.Type+"d",
+			)
+		default:
+			title = fmt.Sprintf(
+				"%s `%s` in of cluster `%s`, namespace `%s` has been %s:",
+				event.Kind,
+				event.Name,
+				event.Cluster,
+				event.Namespace,
+				event.Type+"d",
+			)
+		}
+	case config.ErrorEvent:
+		switch event.Kind {
+		case "Namespace", "Node", "PersistentVolume", "ClusterRole", "ClusterRoleBinding":
+			title = fmt.Sprintf(
+				"Error Occurred in %s: `%s` of cluster `%s`:",
+				event.Kind,
+				event.Name,
+				event.Cluster,
+			)
+		default:
+			title = fmt.Sprintf(
+				"Error Occurred in %s: `%s` of cluster `%s`, namespace `%s`:",
+				event.Kind,
+				event.Name,
+				event.Cluster,
+				event.Namespace,
+			)
+		}
+	case config.WarningEvent:
+		switch event.Kind {
+		case "Namespace", "Node", "PersistentVolume", "ClusterRole", "ClusterRoleBinding":
+			title = fmt.Sprintf(
+				"Warning %s: `%s` of cluster `%s`:",
+				event.Kind,
+				event.Name,
+				event.Cluster,
+			)
+		default:
+			title = fmt.Sprintf(
+				"Warning %s: `%s` of cluster `%s`, namespace `%s`:",
+				event.Kind,
+				event.Name,
+				event.Cluster,
+				event.Namespace,
+			)
+		}
+	}
+	return title
+}

--- a/pkg/notify/msteams_test.go
+++ b/pkg/notify/msteams_test.go
@@ -1,0 +1,46 @@
+package notify
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Unit test PostCard
+func TestPostCard(t *testing.T) {
+	tests := map[string]struct {
+		server   *httptest.Server
+		expected error
+	}{
+		`Status Not Ok`: {
+			httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			})),
+			fmt.Errorf("Failed sending to the Teams Channel. Teams http response: %s, %s", string(http.StatusServiceUnavailable), ""),
+		},
+		`Status Ok`: {
+			httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})),
+			nil,
+		},
+	}
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			ts := test.server
+			defer ts.Close()
+			// create a dummy MsTeams object to test
+			m := &MsTeams{
+				URL:         ts.URL,
+				ClusterName: "test",
+			}
+
+			_, err := m.PostCard(&MessageCard{})
+			assert.Equal(t, test.expected, err)
+		})
+	}
+}

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,4 +1,3 @@
-## test_config.yaml for Integration Testing
 ## Resources you want to watch
 resources:
   - name: pod                # Name of the resources e.g pod, deployment, ingress, etc.
@@ -210,7 +209,13 @@ communications:
       type: botkube-event
       shards: 1
       replicas: 0
-  
+
+  # Settings for MsTeams
+  msteams:
+    enabled: true
+    url: 'MSTEAMS_WEBHOOK_URL'                 # e.g https://example.com:80
+    notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
+
   # Settings for Webhook
   webhook:
     enabled: true

--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/infracloudio/botkube/pkg/config"
-	"github.com/infracloudio/botkube/pkg/execute"
+	exec "github.com/infracloudio/botkube/pkg/execute"
 	"github.com/infracloudio/botkube/test/e2e/utils"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +28,7 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 	tests := map[string]botkubeCommand{
 		"BotKube ping": {
 			command:  "ping",
-			expected: fmt.Sprintf("```pong from cluster '%s'\n\nK8s Server Version: %s\nBotKube version: %s```", c.Config.Settings.ClusterName, execute.K8sVersion, botkubeVersion),
+			expected: fmt.Sprintf("```pong from cluster '%s'\n\nK8s Server Version: %s\nBotKube version: %s```", c.Config.Settings.ClusterName, exec.K8sVersion, botkubeVersion),
 		},
 		"BotKube filters list": {
 			command: "filters list",

--- a/test/e2e/command/kubectl.go
+++ b/test/e2e/command/kubectl.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/infracloudio/botkube/pkg/execute"
+	exec "github.com/infracloudio/botkube/pkg/execute"
 	"github.com/infracloudio/botkube/test/e2e/env"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +26,7 @@ func (c *context) testKubectlCommand(t *testing.T) {
 	tests := map[string]kubectlCommand{
 		"BotKube get pods": {
 			command:  "get pods",
-			expected: fmt.Sprintf("```Cluster: %s\n%s```", c.Config.Settings.ClusterName, execute.KubectlResponse["-n default get pods"]),
+			expected: fmt.Sprintf("```Cluster: %s\n%s```", c.Config.Settings.ClusterName, exec.KubectlResponse["-n default get pods"]),
 		},
 	}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -44,6 +44,14 @@ func TestRun(t *testing.T) {
 		notifiers = append(notifiers, fakeWebhookNotifier)
 	}
 
+	if testEnv.Config.Communications.MsTeams.Enabled {
+		fakeMsTeamsNotifier := &notify.MsTeams{
+			URL:         testEnv.MsTeamsServer.GetAPIURL(),
+			ClusterName: testEnv.Config.Settings.ClusterName,
+		}
+		notifiers = append(notifiers, fakeMsTeamsNotifier)
+	}
+
 	utils.KubeClient = testEnv.K8sClient
 	utils.InitInformerMap()
 

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -18,6 +18,12 @@ type SlackMessage struct {
 	Attachments []slack.Attachment
 }
 
+// MsTeamsCard structure
+type MsTeamsCard struct {
+	Summary  string           `json:"summary"`
+	Sections []notify.Section `json:"sections"`
+}
+
 // WebhookPayload structure
 type WebhookPayload struct {
 	Summary     string             `json:"summary"`
@@ -31,8 +37,9 @@ type CreateObjects struct {
 	Namespace              string
 	Specs                  runtime.Object
 	NotifType              config.NotifType
-	ExpectedWebhookPayload WebhookPayload
 	ExpectedSlackMessage   SlackMessage
+	ExpectedMsTeamsCard    MsTeamsCard
+	ExpectedWebhookPayload WebhookPayload
 }
 
 // CreateResource with fake client

--- a/test/e2e/welcome/welcome.go
+++ b/test/e2e/welcome/welcome.go
@@ -29,6 +29,15 @@ func (c *context) testWelcome(t *testing.T) {
 		assert.Equal(t, c.TestEnv.Config.Communications.Slack.Channel, m.Channel)
 		assert.Equal(t, expected, m.Text)
 	}
+
+	if c.TestEnv.Config.Communications.MsTeams.Enabled {
+
+		// Get last seen msteams card
+		lastSeenCard := c.GetLastReceivedCard()
+
+		// Convert text message into Slack message structure
+		assert.Equal(t, expected, lastSeenCard.Summary)
+	}
 }
 
 // E2ETests run welcome tests

--- a/test/msteams/server.go
+++ b/test/msteams/server.go
@@ -1,0 +1,62 @@
+package msteams
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/infracloudio/botkube/test/e2e/utils"
+)
+
+// handle chat.postMessage
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+
+	decoder := json.NewDecoder(r.Body)
+
+	var t utils.MsTeamsCard
+
+	err := decoder.Decode(&t)
+	if err != nil {
+		panic(err)
+	}
+
+	// update message in mutex
+	s.receivedCards.Lock()
+	s.receivedCards.messages = append(s.receivedCards.messages, t)
+	s.receivedCards.Unlock()
+
+}
+
+// NewTestServer returns a slacktest.Server ready to be started
+func NewTestServer() *Server {
+
+	s := &Server{
+		receivedCards: &cardCollection{},
+	}
+	httpserver := httptest.NewUnstartedServer(s)
+	addr := httpserver.Listener.Addr().String()
+	s.ServerAddr = addr
+	s.server = httpserver
+	return s
+}
+
+// Start starts the test server
+func (s *Server) Start() {
+	log.Print("starting Mock MsTeams server")
+	s.server.Start()
+}
+
+// GetAPIURL returns the api url you can pass to msteams
+func (s *Server) GetAPIURL() string {
+	return "http://" + s.ServerAddr + "/"
+}
+
+// GetReceivedCards returns all messages received
+func (s *Server) GetReceivedCards() []utils.MsTeamsCard {
+	s.receivedCards.RLock()
+	m := s.receivedCards.messages
+	s.receivedCards.RUnlock()
+	return m
+}

--- a/test/msteams/types.go
+++ b/test/msteams/types.go
@@ -1,0 +1,21 @@
+package msteams
+
+import (
+	"net/http/httptest"
+	"sync"
+
+	"github.com/infracloudio/botkube/test/e2e/utils"
+)
+
+// cardCollection mutex to hold incoming message cards
+type cardCollection struct {
+	sync.RWMutex
+	messages []utils.MsTeamsCard
+}
+
+// Server represents a Webhook Test server
+type Server struct {
+	server        *httptest.Server
+	ServerAddr    string
+	receivedCards *cardCollection
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR,
- adds support for event notifications through Microsoft Teams.
- updates configs in all yaml files.
- updates helm values.yaml.
- adds unit tests for msteams notifier
- adds integration test msteams notifier
- adds test/msteams package to enable integration testing.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

Fixes #60

### Steps For Configuring MsTeams Notifier:

- Create your [MsTeams](https://products.office.com/en-us/microsoft-teams/group-chat-software) Account.
- Configure [Incomming Webhooks](https://kb.itglue.com/hc/en-us/articles/115001798191-Setting-up-Microsoft-Teams-webhook-notifications) for your channels. (Note: follow the first 7 steps in the tutorial)
- Place the generated `Webhook Url` under MsTesms section in `config.yaml`
```
  # Settings for MsTeams
    msteams:
      enabled: true
      url: 'MSTEAMS_WEBHOOK_URL'                 # e.g https://example.com:80
      notiftype: short                           # Change notification type 
```
- Start Botkube Server and say Tadaa..!! :tada: 

**Preview**:

![pod error: long notif](https://user-images.githubusercontent.com/30741615/64065063-4f229200-cc26-11e9-9e17-08b3a6260037.png)

![pod create : short notif](https://user-images.githubusercontent.com/30741615/64065064-4fbb2880-cc26-11e9-84aa-ac482223d3f2.png)
