### PR TITLE
Configure default namespace for kubectl cmds through config

### DIFF
--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -209,10 +209,14 @@ data:
     settings:
       # Cluster name to differentiate incoming messages
       clustername: not-configured
-      # Set true to enable kubectl commands execution
-      allowkubectl: false
-      # Set true to enable commands execution from configured channel only
-      restrictAccess: false
+      # Kubectl executor configs
+      kubectl:
+        # Set true to enable kubectl commands execution
+        enabled: false
+        # set Namespace to execute botkube kubectl commands by default
+        defaultNamespace: default
+        # Set true to enable commands execution from configured channel only
+        restrictAccess: false
       # Set true to enable config watcher
       configwatcher: true
       # Set false to disable upgrade notification

--- a/deploy-all-in-one.yaml
+++ b/deploy-all-in-one.yaml
@@ -209,10 +209,14 @@ data:
     settings:
       # Cluster name to differentiate incoming messages
       clustername: not-configured
-      # Set true to enable kubectl commands execution
-      allowkubectl: false
-      # Set true to enable commands execution from configured channel only
-      restrictAccess: false
+      # Kubectl executor configs
+      kubectl:
+        # Set true to enable kubectl commands execution
+        enabled: false
+        # set Namespace to execute botkube kubectl commands by default
+        defaultNamespace: default
+        # Set true to enable commands execution from configured channel only
+        restrictAccess: false
       # Set true to enable config watcher
       configwatcher: true
       # Set false to disable upgrade notification

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -227,10 +227,14 @@ config:
   settings:
     # Cluster name to differentiate incoming messages
     clustername: not-configured
-    # Set true to enable kubectl commands execution
-    allowkubectl: false
-    # Set true to enable commands execution from configured channel only
-    restrictAccess: false
+    # Kubectl executor configs
+    kubectl:
+      # Set true to enable kubectl commands execution
+      enabled: false
+      # set Namespace to execute botkube kubectl commands by default
+      defaultNamespace: default
+      # Set true to enable commands execution from configured channel only
+      restrictAccess: false
     # Set true to enable config watcher
     configwatcher: true
     # Set false to disable upgrade notification

--- a/pkg/bot/mattermost.go
+++ b/pkg/bot/mattermost.go
@@ -49,16 +49,17 @@ const (
 
 // MMBot listens for user's message, execute commands and sends back the response
 type MMBot struct {
-	Token          string
-	TeamName       string
-	ChannelName    string
-	ClusterName    string
-	AllowKubectl   bool
-	RestrictAccess bool
-	ServerURL      string
-	WebSocketURL   string
-	WSClient       *model.WebSocketClient
-	APIClient      *model.Client4
+	Token            string
+	TeamName         string
+	ChannelName      string
+	ClusterName      string
+	AllowKubectl     bool
+	RestrictAccess   bool
+	ServerURL        string
+	WebSocketURL     string
+	WSClient         *model.WebSocketClient
+	APIClient        *model.Client4
+	DefaultNamespace string
 }
 
 // mattermostMessage contains message details to execute command and send back the result
@@ -78,13 +79,14 @@ func NewMattermostBot() Bot {
 	}
 
 	return &MMBot{
-		ServerURL:      c.Communications.Mattermost.URL,
-		Token:          c.Communications.Mattermost.Token,
-		TeamName:       c.Communications.Mattermost.Team,
-		ChannelName:    c.Communications.Mattermost.Channel,
-		ClusterName:    c.Settings.ClusterName,
-		AllowKubectl:   c.Settings.AllowKubectl,
-		RestrictAccess: c.Settings.RestrictAccess,
+		ServerURL:        c.Communications.Mattermost.URL,
+		Token:            c.Communications.Mattermost.Token,
+		TeamName:         c.Communications.Mattermost.Team,
+		ChannelName:      c.Communications.Mattermost.Channel,
+		ClusterName:      c.Settings.ClusterName,
+		AllowKubectl:     c.Settings.Kubectl.Enabled,
+		RestrictAccess:   c.Settings.Kubectl.RestrictAccess,
+		DefaultNamespace: c.Settings.Kubectl.DefaultNamespace,
 	}
 }
 
@@ -152,7 +154,7 @@ func (mm *mattermostMessage) handleMessage(b MMBot) {
 	// Trim the @BotKube prefix if exists
 	mm.Request = strings.TrimPrefix(post.Message, "@"+BotName+" ")
 
-	e := execute.NewDefaultExecutor(mm.Request, b.AllowKubectl, b.RestrictAccess, b.ClusterName, b.ChannelName, mm.IsAuthChannel)
+	e := execute.NewDefaultExecutor(mm.Request, b.AllowKubectl, b.RestrictAccess, b.DefaultNamespace, b.ClusterName, b.ChannelName, mm.IsAuthChannel)
 	mm.Response = e.Execute()
 	mm.sendMessage()
 }

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -31,13 +31,14 @@ import (
 
 // SlackBot listens for user's message, execute commands and sends back the response
 type SlackBot struct {
-	Token          string
-	AllowKubectl   bool
-	RestrictAccess bool
-	ClusterName    string
-	ChannelName    string
-	SlackURL       string
-	BotID          string
+	Token            string
+	AllowKubectl     bool
+	RestrictAccess   bool
+	ClusterName      string
+	ChannelName      string
+	SlackURL         string
+	BotID            string
+	DefaultNamespace string
 }
 
 // slackMessage contains message details to execute command and send back the result
@@ -58,11 +59,12 @@ func NewSlackBot() Bot {
 		logging.Logger.Fatal(fmt.Sprintf("Error in loading configuration. Error:%s", err.Error()))
 	}
 	return &SlackBot{
-		Token:          c.Communications.Slack.Token,
-		AllowKubectl:   c.Settings.AllowKubectl,
-		RestrictAccess: c.Settings.RestrictAccess,
-		ClusterName:    c.Settings.ClusterName,
-		ChannelName:    c.Communications.Slack.Channel,
+		Token:            c.Communications.Slack.Token,
+		AllowKubectl:     c.Settings.Kubectl.Enabled,
+		RestrictAccess:   c.Settings.Kubectl.RestrictAccess,
+		ClusterName:      c.Settings.ClusterName,
+		ChannelName:      c.Communications.Slack.Channel,
+		DefaultNamespace: c.Settings.Kubectl.DefaultNamespace,
 	}
 }
 
@@ -158,7 +160,7 @@ func (sm *slackMessage) HandleMessage(b *SlackBot) {
 		return
 	}
 
-	e := execute.NewDefaultExecutor(sm.Request, b.AllowKubectl, b.RestrictAccess, b.ClusterName, b.ChannelName, sm.IsAuthChannel)
+	e := execute.NewDefaultExecutor(sm.Request, b.AllowKubectl, b.RestrictAccess, b.DefaultNamespace, b.ClusterName, b.ChannelName, sm.IsAuthChannel)
 	sm.Response = e.Execute()
 	sm.Send()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,11 +147,17 @@ type Webhook struct {
 	URL     string
 }
 
+// Kubectl configuration for executing commands inside cluster
+type Kubectl struct {
+	Enabled          bool
+	DefaultNamespace string
+	RestrictAccess   bool `yaml:"restrictAccess"`
+}
+
 // Settings for multicluster support
 type Settings struct {
 	ClusterName     string
-	AllowKubectl    bool
-	RestrictAccess  bool `yaml:"restrictAccess"`
+	Kubectl         Kubectl
 	ConfigWatcher   bool
 	UpgradeNotifier bool `yaml:"upgradeNotifier"`
 }

--- a/resource_config.yaml
+++ b/resource_config.yaml
@@ -203,10 +203,14 @@ recommendations: true
 settings:
   # Cluster name to differentiate incoming messages
   clustername: not-configured
-  # Set true to enable kubectl commands execution
-  allowkubectl: false
-  # Set true to enable commands execution from configured channel only
-  restrictAccess: false
+  # Kubectl executor configs
+  kubectl:
+    # Set true to enable kubectl commands execution
+    enabled: false
+    # set Namespace to execute botkube kubectl commands by default
+    defaultNamespace: default
+    # Set true to enable commands execution from configured channel only
+    restrictAccess: false
   # Set true to enable config watcher
   configwatcher: true
   # Set false to disable upgrade notification

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -96,13 +96,14 @@ func StartFakeSlackBot(testenv *env.TestEnv) {
 
 		// Fake bot
 		sb := &bot.SlackBot{
-			Token:          testenv.Config.Communications.Slack.Token,
-			AllowKubectl:   testenv.Config.Settings.AllowKubectl,
-			RestrictAccess: testenv.Config.Settings.RestrictAccess,
-			ClusterName:    testenv.Config.Settings.ClusterName,
-			ChannelName:    testenv.Config.Communications.Slack.Channel,
-			SlackURL:       testenv.SlackServer.GetAPIURL(),
-			BotID:          testenv.SlackServer.BotID,
+			Token:            testenv.Config.Communications.Slack.Token,
+			AllowKubectl:     testenv.Config.Settings.Kubectl.Enabled,
+			RestrictAccess:   testenv.Config.Settings.Kubectl.RestrictAccess,
+			ClusterName:      testenv.Config.Settings.ClusterName,
+			ChannelName:      testenv.Config.Communications.Slack.Channel,
+			SlackURL:         testenv.SlackServer.GetAPIURL(),
+			BotID:            testenv.SlackServer.BotID,
+			DefaultNamespace: testenv.Config.Settings.Kubectl.DefaultNamespace,
 		}
 		go sb.Start()
 	}

--- a/test/resource_config.yaml
+++ b/test/resource_config.yaml
@@ -203,10 +203,14 @@ recommendations: true
 settings:
   # Cluster name to differentiate incoming messages
   clustername: test-cluster-1
-  # Set true to enable kubectl commands execution
-  allowkubectl: true
-  # Set true to enable commands execution from configured channel only
-  restrictAccess: true
+  # Kubectl executor configs
+  kubectl:
+    # Set true to enable kubectl commands execution
+    enabled: true
+    # set Namespace to execute botkube kubectl commands by default
+    defaultNamespace: default
+    # Set true to enable commands execution from configured channel only
+    restrictAccess: true
   # Set true to enable config watcher
   configwatcher: false
   # Set false to disable upgrade notification


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This Commit,
- Adds `kubectl.Enabled`, `Kubectl.DefaultNamespace` to `Config.Settings` to configure default namespace, under which all  botkube kubectl commands will be executed by default.
- changes `Settings.RestrictAccess` into `Settings. Kubectl.RestrictAccess` 
- updates all config.yaml files
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

Fixes #176

**Preview**:

```yaml
settings:
  # Kubectl executor configs
  kubectl:
    # Set true to enable kubectl commands execution
    enabled: false
    # set Namespace to execute botkube kubectl commands by default
    defaultNamespace: default
    # Set true to enable commands execution from configured channel only
    restrictAccess: false
```