### PR TITLE
Add pod security policy so botkube works in restricted clusters

### DIFF
--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -272,7 +272,7 @@ subjects:
   name: botkube-sa
   namespace: botkube
 ---
-# Secret
+# Certificate for Mattermost integration: https://www.botkube.io/installation/mattermost/
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -11,27 +11,27 @@ data:
     ## Resources you want to watch
     resources:
         namespaces:
-          include:  
+          include:
             - all
           ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all
-            -                     # example : include [all], ignore [x,y,z] 
+            -                     # example : include [all], ignore [x,y,z]
         events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
           - create
           - delete
           - error
       - name: service
         namespaces:
-          include:  
+          include:
             - all
           ignore:
-            - 
+            -
         events:
           - create
           - delete
           - error
       - name: deployment
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -42,7 +42,7 @@ data:
           - error
       - name: statefulset
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -53,7 +53,7 @@ data:
           - error
       - name: ingress
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -63,7 +63,7 @@ data:
           - error
       - name: node
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -73,7 +73,7 @@ data:
           - error
       - name: namespace
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -83,7 +83,7 @@ data:
           - error
       - name: persistentvolume
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -93,7 +93,7 @@ data:
           - error
       - name: persistentvolumeclaim
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -103,7 +103,7 @@ data:
           - error
       - name: secret
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -113,7 +113,7 @@ data:
           - error
       - name: configmap
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -123,7 +123,7 @@ data:
           - error
       - name: daemonset
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -134,7 +134,7 @@ data:
           - error
       - name: job
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -145,7 +145,7 @@ data:
           - error
       - name: role
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -155,7 +155,7 @@ data:
           - error
       - name: rolebinding
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -175,7 +175,7 @@ data:
           - error
       - name: clusterrolebinding
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -183,11 +183,11 @@ data:
           - create
           - delete
           - error
-  
+
     # Check true if you want to receive recommendations
     # about the best practices for the created resource
     recommendations: true
-    
+
     # Channels configuration
     communications:
       # Settings for Slack
@@ -196,7 +196,7 @@ data:
         channel: 'SLACK_CHANNEL'
         token: 'SLACK_API_TOKEN'
         notiftype: short                            # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
-      
+
       # Settings for Mattermost
       mattermost:
         enabled: false
@@ -205,7 +205,7 @@ data:
         team: 'MATTERMOST_TEAM'                     # Mattermost Team to configure with BotKube
         channel: 'MATTERMOST_CHANNEL'               # Mattermost Channel for receiving BotKube alerts
         notiftype: short                            # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
-      
+
       # Settings for ELS
       elasticsearch:
         enable: false
@@ -218,13 +218,13 @@ data:
           type: botkube-event
           shards: 1
           replicas: 0
-      
+
       # Settings for Webhook
       webhook:
         enabled: false
         url: 'WEBHOOK_URL'                          # e.g https://example.com:80
 
-  
+
     # Setting to support multiple clusters
     settings:
       # Cluster name to differentiate incoming messages
@@ -278,9 +278,9 @@ kind: Secret
 metadata:
   name: botkube-secret
   labels:
-    app: botkube 
+    app: botkube
 data:
-  ca-certificates.crt: ENCODED_CERTIFICATE 
+  ca-certificates.crt: ENCODED_CERTIFICATE
 ---
 # deployment
 apiVersion: apps/v1

--- a/deploy-all-in-one.yaml
+++ b/deploy-all-in-one.yaml
@@ -12,27 +12,27 @@ data:
     resources:
       - name: pod                # Name of the resources e.g pod, deployment, ingress, etc. (Resource name must be in singular form)
         namespaces:
-          include:  
+          include:
             - all
           ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all
-            -                     # example : include [all], ignore [x,y,z] 
+            -                     # example : include [all], ignore [x,y,z]
         events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
           - create
           - delete
           - error
       - name: service
         namespaces:
-          include:  
+          include:
             - all
           ignore:
-            - 
+            -
         events:
           - create
           - delete
           - error
       - name: deployment
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -43,7 +43,7 @@ data:
           - error
       - name: statefulset
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -54,7 +54,7 @@ data:
           - error
       - name: ingress
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -64,7 +64,7 @@ data:
           - error
       - name: node
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -74,7 +74,7 @@ data:
           - error
       - name: namespace
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -84,7 +84,7 @@ data:
           - error
       - name: persistentvolume
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -94,7 +94,7 @@ data:
           - error
       - name: persistentvolumeclaim
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -104,7 +104,7 @@ data:
           - error
       - name: secret
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -114,7 +114,7 @@ data:
           - error
       - name: configmap
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -124,7 +124,7 @@ data:
           - error
       - name: daemonset
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -135,7 +135,7 @@ data:
           - error
       - name: job
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -146,7 +146,7 @@ data:
           - error
       - name: role
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -156,7 +156,7 @@ data:
           - error
       - name: rolebinding
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -176,7 +176,7 @@ data:
           - error
       - name: clusterrolebinding
         namespaces:
-          include:  
+          include:
             - all
           ignore:
             -
@@ -184,11 +184,11 @@ data:
           - create
           - delete
           - error
-  
+
     # Check true if you want to receive recommendations
     # about the best practices for the created resource
     recommendations: true
-    
+
     # Channels configuration
     communications:
       # Settings for Slack
@@ -197,7 +197,7 @@ data:
         channel: 'SLACK_CHANNEL'
         token: 'SLACK_API_TOKEN'
         notiftype: short                            # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
-      
+
       # Settings for Mattermost
       mattermost:
         enabled: false
@@ -206,7 +206,7 @@ data:
         team: 'MATTERMOST_TEAM'                     # Mattermost Team to configure with BotKube
         channel: 'MATTERMOST_CHANNEL'               # Mattermost Channel for receiving BotKube alerts
         notiftype: short                            # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
-      
+
       # Settings for ELS
       elasticsearch:
         enable: false
@@ -219,7 +219,7 @@ data:
           type: botkube-event
           shards: 1
           replicas: 0
-      
+
       # Settings for Webhook
       webhook:
         enabled: false

--- a/helm/botkube/templates/clusterrole.yaml
+++ b/helm/botkube/templates/clusterrole.yaml
@@ -11,3 +11,9 @@ rules:
   - apiGroups: ["*"]
     resources: ["*"]
     verbs: ["get", "watch", "list"]
+{{- if .Values.podSecurityPolicy.enabled }}
+  - apiGroups: ["extensions"]
+    resourceNames: ["botkube-psp"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]}
+{{ end }}

--- a/helm/botkube/templates/podsecuritypolicy.yaml
+++ b/helm/botkube/templates/podsecuritypolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "botkube.fullname" . }}-psp
+  labels:
+    app.kubernetes.io/name: {{ include "botkube.name" . }}
+    helm.sh/chart: {{ include "botkube.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  allowedUnsafeSysctls: ['*']
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes: ['*']
+{{ end }}

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -14,6 +14,10 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# Enable podSecurityPolicy to allow botkube to run in restricted clusters
+podSecurityPolicy:
+  enabled: false
+
 # Configure securityContext to manage user Privileges in pods
 # set to run as a Non-Privileged user by default
 securityContext:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY
- When attempting to install either the develop branch or v0.8.0 of botkube via helm, the botkube deployment pod crashes repeatedly due to a security permissions issue. From what I can tell, the botkube docker image references a system user by name rather than UID, which may violate default pod security policies in restricted environments (at least in v0.8.0). In addition, the pod appears to use [unsafe sysctls](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#enabling-unsafe-sysctls), as this setting is required for the pod to run without crashing.

- After making the above changes and restarting the botkube pod in CrashLoop backoff, the pod was able to run continuously and began working correctly. We were able to issue kubectl commands to botkube as well as receive event notifications in the Slack channel.

##### EVIDENCE

Sample output below, and I've attached the logs of the pod as a file.

**v0.8.0**
```
NAME                       READY   STATUS                       RESTARTS   AGE
botkube-7c58899999-zn7r5   0/1     CreateContainerConfigError   0          4m36s
```
```
Events:
  Type     Reason     Age                  From                                   Message
  ----     ------     ----                 ----                                   -------
  Normal   Scheduled  2m54s                default-scheduler                      Successfully assigned botkube/botkube-7c58899999-zn7r5 to <redacted>
  Normal   Pulled     90s (x8 over 2m53s)  <redacted>  Successfully pulled image "infracloud/botkube:latest"
  Warning  Failed     90s (x8 over 2m53s)  <redacted>  Error: container has runAsNonRoot and image has non-numeric user (botkube), cannot verify user is non-root
  Normal   Pulling    74s (x9 over 2m53s)  <redacted>  pulling image "infracloud/botkube:latest"
```
**develop (commit 8835dea14463e8d9110c17a1892704759f5e2b9f)**
```
NAME                       READY   STATUS             RESTARTS   AGE
botkube-544f67c9d8-whj8d   0/1     CrashLoopBackOff   4          3m1s
```
```
Events:
  Type     Reason     Age                From                                   Message
  ----     ------     ----               ----                                   -------
  Normal   Scheduled  24s                default-scheduler                      Successfully assigned botkube/botkube-544f67c9d8-sf8x8 to <redacted>
  Normal   Pulling    15s (x2 over 23s)  <redacted>  pulling image "infracloudio/botkube:latest"
  Normal   Pulled     15s (x2 over 23s)  <redacted>  Successfully pulled image "infracloudio/botkube:latest"
  Normal   Created    15s (x2 over 23s)  <redacted>  Created container
  Normal   Started    15s (x2 over 22s)  <redacted>  Started container
  Warning  BackOff    9s                 <redacted>  Back-off restarting failed container
```
[pod-logs.txt](https://github.com/infracloudio/botkube/files/3714932/pod-logs.txt)

Thank you and please let me know if you have any questions about these changes.