### PR TITLE
Fix helm/botkube/values.yaml clusterrole namespace info

### DIFF
--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -181,7 +181,10 @@ config:
         - error
     - name: clusterrole
       namespaces:
-        - all
+        include:
+          - all
+        ignore:
+          - 
       events:
         - create
         - delete


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY
Fixes #194 
helm/botkube/values.yaml file fix
missing 'include', 'ignore' keyword, so fix it.

