### PR TITLE
Add colors to Mattermost notification attachments

### DIFF
--- a/pkg/notify/mattermost.go
+++ b/pkg/notify/mattermost.go
@@ -66,6 +66,7 @@ func (m *Mattermost) SendEvent(event events.Event) error {
 
 	attachment := []*model.SlackAttachment{
 		{
+			Color:     attachmentColor[event.Level],
 			Title:     event.Title,
 			Fields:    fields,
 			Footer:    "BotKube",


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add colors based on notification type to the attachments
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->
![image](https://user-images.githubusercontent.com/7098659/69520599-1e32ce80-0f83-11ea-949d-e336d224e198.png)
![image](https://user-images.githubusercontent.com/7098659/69520617-2559dc80-0f83-11ea-80a4-021cd6cbe316.png)
