### PR TITLE
Added restrictAccess flag to enable/disable behavior of botkube. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 vendor/
+/.idea/
+/botkube

--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -184,6 +184,8 @@ data:
       clustername: not-configured
       # Set true to enable kubectl commands execution
       allowkubectl: false
+      # Set true to enable commands execution from configured channel only
+      restrictAccess: false
       # Set true to enable config watcher
       configwatcher: true
       # Set false to disable upgrade notification

--- a/deploy-all-in-one.yaml
+++ b/deploy-all-in-one.yaml
@@ -185,6 +185,8 @@ data:
       clustername: not-configured
       # Set true to enable kubectl commands execution
       allowkubectl: false
+      # Set true to enable commands execution from configured channel only
+      restrictAccess: false
       # Set true to enable config watcher
       configwatcher: true
       # Set false to disable upgrade notification

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -208,6 +208,8 @@ config:
     clustername: not-configured
     # Set true to enable kubectl commands execution
     allowkubectl: false
+    # Set true to enable commands execution from configured channel only
+    restrictAccess: false
     # Set true to enable config watcher
     configwatcher: true
     # Set false to disable upgrade notification

--- a/pkg/bot/mattermost.go
+++ b/pkg/bot/mattermost.go
@@ -30,15 +30,16 @@ const (
 
 // MMBot listens for user's message, execute commands and sends back the response
 type MMBot struct {
-	Token        string
-	TeamName     string
-	ChannelName  string
-	ClusterName  string
-	AllowKubectl bool
-	ServerURL    string
-	WebSocketURL string
-	WSClient     *model.WebSocketClient
-	APIClient    *model.Client4
+	Token          string
+	TeamName       string
+	ChannelName    string
+	ClusterName    string
+	AllowKubectl   bool
+	RestrictAccess bool
+	ServerURL      string
+	WebSocketURL   string
+	WSClient       *model.WebSocketClient
+	APIClient      *model.Client4
 }
 
 // mattermostMessage contains message details to execute command and send back the result
@@ -58,12 +59,13 @@ func NewMattermostBot() Bot {
 	}
 
 	return &MMBot{
-		ServerURL:    c.Communications.Mattermost.URL,
-		Token:        c.Communications.Mattermost.Token,
-		TeamName:     c.Communications.Mattermost.Team,
-		ChannelName:  c.Communications.Mattermost.Channel,
-		ClusterName:  c.Settings.ClusterName,
-		AllowKubectl: c.Settings.AllowKubectl,
+		ServerURL:      c.Communications.Mattermost.URL,
+		Token:          c.Communications.Mattermost.Token,
+		TeamName:       c.Communications.Mattermost.Team,
+		ChannelName:    c.Communications.Mattermost.Channel,
+		ClusterName:    c.Settings.ClusterName,
+		AllowKubectl:   c.Settings.AllowKubectl,
+		RestrictAccess: c.Settings.RestrictAccess,
 	}
 }
 
@@ -131,7 +133,7 @@ func (mm *mattermostMessage) handleMessage(b MMBot) {
 	// Trim the @BotKube prefix if exists
 	mm.Request = strings.TrimPrefix(post.Message, "@"+BotName+" ")
 
-	e := execute.NewDefaultExecutor(mm.Request, b.AllowKubectl, b.ClusterName, b.ChannelName, mm.IsAuthChannel)
+	e := execute.NewDefaultExecutor(mm.Request, b.AllowKubectl, b.RestrictAccess, b.ClusterName, b.ChannelName, mm.IsAuthChannel)
 	mm.Response = e.Execute()
 	mm.sendMessage()
 }

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -12,12 +12,13 @@ import (
 
 // SlackBot listens for user's message, execute commands and sends back the response
 type SlackBot struct {
-	Token        string
-	AllowKubectl bool
-	ClusterName  string
-	ChannelName  string
-	SlackURL     string
-	BotID        string
+	Token          string
+	AllowKubectl   bool
+	RestrictAccess bool
+	ClusterName    string
+	ChannelName    string
+	SlackURL       string
+	BotID          string
 }
 
 // slackMessage contains message details to execute command and send back the result
@@ -38,10 +39,11 @@ func NewSlackBot() Bot {
 		logging.Logger.Fatal(fmt.Sprintf("Error in loading configuration. Error:%s", err.Error()))
 	}
 	return &SlackBot{
-		Token:        c.Communications.Slack.Token,
-		AllowKubectl: c.Settings.AllowKubectl,
-		ClusterName:  c.Settings.ClusterName,
-		ChannelName:  c.Communications.Slack.Channel,
+		Token:          c.Communications.Slack.Token,
+		AllowKubectl:   c.Settings.AllowKubectl,
+		RestrictAccess: c.Settings.RestrictAccess,
+		ClusterName:    c.Settings.ClusterName,
+		ChannelName:    c.Communications.Slack.Channel,
 	}
 }
 
@@ -137,7 +139,7 @@ func (sm *slackMessage) HandleMessage(b *SlackBot) {
 		return
 	}
 
-	e := execute.NewDefaultExecutor(sm.Request, b.AllowKubectl, b.ClusterName, b.ChannelName, sm.IsAuthChannel)
+	e := execute.NewDefaultExecutor(sm.Request, b.AllowKubectl, b.RestrictAccess, b.ClusterName, b.ChannelName, sm.IsAuthChannel)
 	sm.Response = e.Execute()
 	sm.Send()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -125,6 +125,7 @@ type Webhook struct {
 type Settings struct {
 	ClusterName     string
 	AllowKubectl    bool
+	RestrictAccess  bool `yaml:"restrictAccess"`
 	ConfigWatcher   bool
 	UpgradeNotifier bool `yaml:"upgradeNotifier"`
 }

--- a/resource_config.yaml
+++ b/resource_config.yaml
@@ -185,6 +185,8 @@ settings:
   clustername: not-configured
   # Set true to enable kubectl commands execution
   allowkubectl: false
+  # Set true to enable commands execution from configured channel only
+  restrictAccess: false
   # Set true to enable config watcher
   configwatcher: true
   # Set false to disable upgrade notification

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -77,12 +77,13 @@ func StartFakeSlackBot(testenv *env.TestEnv) {
 
 		// Fake bot
 		sb := &bot.SlackBot{
-			Token:        testenv.Config.Communications.Slack.Token,
-			AllowKubectl: testenv.Config.Settings.AllowKubectl,
-			ClusterName:  testenv.Config.Settings.ClusterName,
-			ChannelName:  testenv.Config.Communications.Slack.Channel,
-			SlackURL:     testenv.SlackServer.GetAPIURL(),
-			BotID:        testenv.SlackServer.BotID,
+			Token:          testenv.Config.Communications.Slack.Token,
+			AllowKubectl:   testenv.Config.Settings.AllowKubectl,
+			RestrictAccess: testenv.Config.Settings.RestrictAccess,
+			ClusterName:    testenv.Config.Settings.ClusterName,
+			ChannelName:    testenv.Config.Communications.Slack.Channel,
+			SlackURL:       testenv.SlackServer.GetAPIURL(),
+			BotID:          testenv.SlackServer.BotID,
 		}
 		go sb.Start()
 	}

--- a/test/resource_config.yaml
+++ b/test/resource_config.yaml
@@ -186,6 +186,8 @@ settings:
   clustername: test-cluster-1
   # Set true to enable kubectl commands execution
   allowkubectl: true
+  # Set true to enable commands execution from configured channel only
+  restrictAccess: true
   # Set true to enable config watcher
   configwatcher: false
   # Set false to disable upgrade notification


### PR DESCRIPTION
This flag will control user's access to botkube via configured channel. If set to true, it will allow user to talk to botkube only through configured channel. In other case, botkube will be accessible from all channels.

Signed-off-by: Mahendra Bagul <mahendra@infracloud.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->
Fix for https://github.com/infracloudio/botkube/issues/235
<!--- Please list dependencies added with your change also -->

