### PR TITLE
Checked cluster name before executing kubectl command

### DIFF
--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -140,11 +140,16 @@ func NewDefaultExecutor(msg string, allowkubectl bool, restrictAccess bool, clus
 // Execute executes commands and returns output
 func (e *DefaultExecutor) Execute() string {
 	args := strings.Fields(e.Message)
+
 	if validKubectlCommands[args[0]] {
-		if !e.AllowKubectl {
-			return fmt.Sprintf(kubectlDisabledMsg, e.ClusterName)
-		}
 		isClusterNamePresent := strings.Contains(e.Message, "--cluster-name")
+		if !e.AllowKubectl {
+			if isClusterNamePresent && e.ClusterName == utils.GetClusterNameFromKubectlCmd(e.Message) {
+				return fmt.Sprintf(kubectlDisabledMsg, e.ClusterName)
+			}
+			return ""
+		}
+
 		if e.RestrictAccess && !e.IsAuthChannel && isClusterNamePresent {
 			return ""
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -401,4 +402,16 @@ func ExtractAnnotaions(obj *coreV1.Event) map[string]string {
 	}
 
 	return map[string]string{}
+}
+
+//GetClusterNameFromKubectlCmd this will return cluster name from kubectl command
+func GetClusterNameFromKubectlCmd(cmd string) string {
+	r, _ := regexp.Compile(`--cluster-name[=|' ']([^\s]*)`)
+	//this gives 2 match with cluster name and without
+	matchedArray := r.FindStringSubmatch(cmd)
+	var s string = ""
+	if len(matchedArray) >= 2 {
+		s = matchedArray[1]
+	}
+	return s
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -409,7 +409,7 @@ func GetClusterNameFromKubectlCmd(cmd string) string {
 	r, _ := regexp.Compile(`--cluster-name[=|' ']([^\s]*)`)
 	//this gives 2 match with cluster name and without
 	matchedArray := r.FindStringSubmatch(cmd)
-	var s string = ""
+	var s string
 	if len(matchedArray) >= 2 {
 		s = matchedArray[1]
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,7 +20,7 @@ func TestGetClusterNameFromKubectlCmd(t *testing.T) {
 		{input: "--cluster-name ", expected: ""},
 		{input: "--cluster-name=", expected: ""},
 		{input: "", expected: ""},
-		{input: "--cluster-name minikube1", expected: "minikube1"},
+		{input: "--cluster-nameminikube1", expected: ""},
 	}
 
 	for _, ts := range tests {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestGetClusterNameFromKubectlCmd(t *testing.T) {
+
+	type test struct {
+		input    string
+		expected string
+	}
+
+	tests := []test{
+		{input: "get pods --cluster-name=minikube", expected: "minikube"},
+		{input: "--cluster-name minikube1", expected: "minikube1"},
+		{input: "--cluster-name minikube2 -n default", expected: "minikube2"},
+		{input: "--cluster-name minikube -n=default", expected: "minikube"},
+		{input: "--cluster-name", expected: ""},
+		{input: "--cluster-name ", expected: ""},
+		{input: "--cluster-name=", expected: ""},
+		{input: "", expected: ""},
+		{input: "--cluster-name minikube1", expected: "minikube1"},
+	}
+
+	for _, ts := range tests {
+		got := GetClusterNameFromKubectlCmd(ts.input)
+		if got != ts.expected {
+			t.Errorf("expected: %v, got: %v", ts.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
This commit fix the bug 230 which shows redundant error message
when deployed in miticluster, added check for cluster name and
created new function to get cluster name from kubectl command

