### PR TITLE
Adding multi-arch support for botkube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ install:
   - ./get_helm.sh
 
 before_script:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - hack/verify-gofmt.sh
   - hack/verify-govet.sh
   - hack/verify-golint.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_script:
   - helm lint helm/botkube
 
 script:
-  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
   - make test
   - make
   - make buildx-container-image-build
@@ -31,6 +30,7 @@ script:
 after_success:
   - |
     if [[ "$TRAVIS_BRANCH" == "develop" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+      docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
       make buildx-container-image-release
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 
 env:
   - GO111MODULE=on
+  - DOCKER_BUILDKIT=1
 
 install:
   - go get -u golang.org/x/lint/golint
@@ -16,10 +17,9 @@ install:
   - ./get_helm.sh
 
 before_script:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker build --platform=local -o . git://github.com/docker/buildx
+  - mkdir -p ~/.docker/cli-plugins
+  - mv buildx ~/.docker/cli-plugins/docker-buildx
   - hack/verify-gofmt.sh
   - hack/verify-govet.sh
   - hack/verify-golint.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ services:
 
 env:
   - GO111MODULE=on
-  - DOCKER_BUILDKIT=1
-  - DOCKER_CLI_EXPERIMENTAL=enabled
 
 install:
   - go get -u golang.org/x/lint/golint
@@ -18,9 +16,11 @@ install:
   - ./get_helm.sh
 
 before_script:
-  - docker build --platform=local -o . git://github.com/docker/buildx
-  - mkdir -p ~/.docker/cli-plugins
-  - mv buildx ~/.docker/cli-plugins/docker-buildx
+  - curl -fsSL https://get.docker.com | sh
+  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - mkdir -p $HOME/.docker
+  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+  - sudo service docker start
   - hack/verify-gofmt.sh
   - hack/verify-govet.sh
   - hack/verify-golint.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 env:
   - GO111MODULE=on
   - DOCKER_BUILDKIT=1
+  - DOCKER_CLI_EXPERIMENTAL=enabled
 
 install:
   - go get -u golang.org/x/lint/golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ before_script:
   - helm lint helm/botkube
 
 script:
+  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
   - make test
   - make
-  - make container-image
+  - make buildx-container-image-build
 
 after_success:
   - |
     if [[ "$TRAVIS_BRANCH" == "develop" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-      docker push infracloudio/botkube:latest
+      make buildx-container-image-release
     fi
 
   - |

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,8 @@ build: pre-build
 	@cd cmd/botkube;GOOS_VAL=$(shell go env GOOS) GOARCH_VAL=$(shell go env GOARCH) go build -o $(shell go env GOPATH)/bin/botkube
 	@echo "Build completed successfully"
 
-# Build the image
-container-image: pre-build
-	@echo "Building docker image"
-	@docker build --build-arg GOOS_VAL=$(shell go env GOOS) --build-arg GOARCH_VAL=$(shell go env GOARCH) -t $(IMAGE_REPO) -f build/Dockerfile --no-cache .
-	@echo "Docker image build successfully"
-
 # Buildx, Tag & Push Dev
-buildx-container-image-build: pre-build
+buildx-container-image-build:
 	export DOCKER_CLI_EXPERIMENTAL=enabled
 	@if ! docker buildx ls | grep -q container-builder; then\
 		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\
@@ -51,10 +45,10 @@ buildx-container-image-build: pre-build
 	docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" \
 		-t $(IMAGE_REPO):$(DEV_TAG) \
 		-f build/Dockerfile \
-		. --push
+		.
 
 # Buildx, Tag & Push Release
-buildx-container-image-release: pre-built
+buildx-container-image-release:
 	export DOCKER_CLI_EXPERIMENTAL=enabled
 	@if ! docker buildx ls | grep -q container-builder; then\
 		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 IMAGE_REPO=infracloudio/botkube
-TAG=$(shell cut -d'=' -f2- .release)
+DEV_TAG=$(shell git rev-parse --short HEAD)
+RELEASE_TAG=$(shell cut -d'=' -f2- .release)
 
 .DEFAULT_GOAL := build
 .PHONY: release git-tag check-git-status build container-image pre-build tag-image publish test system-check
@@ -7,21 +8,21 @@ TAG=$(shell cut -d'=' -f2- .release)
 #Docker Tasks
 #Make a release
 release: check-git-status test container-image tag-image publish git-tag
-	@echo "Successfully releeased version $(TAG)"
+	@echo "Successfully releeased version $(RELEASE_TAG)"
 
 #Create a git tag
 git-tag:
 	@echo "Creating a git tag"
 	@git add .release helm/botkube deploy-all-in-one.yaml deploy-all-in-one-tls.yaml CHANGELOG.md
-	@git commit -m "Release $(TAG)" ;
-	@git tag $(TAG) ;
+	@git commit -m "Release $(RELEASE_TAG)" ;
+	@git tag $(RELEASE_TAG) ;
 	@git push --tags origin develop;
 	@echo 'Git tag pushed successfully' ;
 
 #Check git status
 check-git-status:
 	@echo "Checking git status"
-	@if [ -n "$(shell git tag | grep $(TAG))" ] ; then echo 'ERROR: Tag already exists' && exit 1 ; fi
+	@if [ -n "$(shell git tag | grep $(RELEASE_TAG))" ] ; then echo 'ERROR: Tag already exists' && exit 1 ; fi
 	@if [ -z "$(shell git remote -v)" ] ; then echo 'ERROR: No remote to push tags to' && exit 1 ; fi
 	@if [ -z "$(shell git config user.email)" ] ; then echo 'ERROR: Unable to detect git credentials' && exit 1 ; fi
 
@@ -30,17 +31,41 @@ test: system-check
 	@echo "Starting unit and integration tests"
 	@./hack/runtests.sh
 
-#Build the binary
+# Build the binary
 build: pre-build
-	@cd cmd/botkube;GOOS_VAL=$(shell go env GOOS) GOARCH_VAL=$(shell go env GOARCH) go build -o $(shell go env GOPATH)/bin/botkube 
+	@cd cmd/botkube;GOOS_VAL=$(shell go env GOOS) GOARCH_VAL=$(shell go env GOARCH) go build -o $(shell go env GOPATH)/bin/botkube
 	@echo "Build completed successfully"
-#Build the image
+
+# Build the image
 container-image: pre-build
 	@echo "Building docker image"
 	@docker build --build-arg GOOS_VAL=$(shell go env GOOS) --build-arg GOARCH_VAL=$(shell go env GOARCH) -t $(IMAGE_REPO) -f build/Dockerfile --no-cache .
 	@echo "Docker image build successfully"
 
-#system checks
+# Buildx, Tag & Push Dev
+buildx-container-image-build: pre-build
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	@if ! docker buildx ls | grep -q container-builder; then\
+		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\
+	fi
+	docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" \
+		-t $(IMAGE_REPO):$(DEV_TAG) \
+		-f build/Dockerfile \
+		. --push
+
+# Buildx, Tag & Push Release
+buildx-container-image-release: pre-built
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	@if ! docker buildx ls | grep -q container-builder; then\
+		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\
+	fi
+	docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" \
+		-t $(IMAGE_REPO):$(RELEASE_TAG) \
+		-t $(IMAGE_REPO):latest \
+		-f build/Dockerfile \
+		. --push
+
+# system checks
 system-check:
 	@echo "Checking system information"
 	@if [ -z "$(shell go env GOOS)" ] || [ -z "$(shell go env GOARCH)" ] ; \
@@ -58,11 +83,11 @@ pre-build: system-check
 #Tag images
 tag-image:
 	@echo 'Tagging image'
-	@docker tag $(IMAGE_REPO) $(IMAGE_REPO):$(TAG)
+	@docker tag $(IMAGE_REPO) $(IMAGE_REPO):$(RELEASE_TAG)
 
 #Docker push image
 publish:
 	@echo "Pushing docker image to repository"
 	@docker login
-	@docker push $(IMAGE_REPO):$(TAG)
+	@docker push $(IMAGE_REPO):$(RELEASE_TAG)
 	@docker push $(IMAGE_REPO):latest

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,9 +18,12 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Development image
-FROM golang:1.12-alpine3.10 AS BUILD-ENV
+FROM golang:1.14-alpine AS build
 
 ARG TARGETPLATFORM
+
+ENV GO111MODULE=on \
+    CGO_ENABLED=0
 
 # Add git
 RUN apk update && apk add git curl
@@ -38,12 +41,11 @@ COPY . .
 RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
     export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
     GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3); export GOARM=${GOARM:1} && \
-    go build -o /go/bin/botkube ./cmd/botkube
-
-# Install kubectl binary
-RUN apk add --no-cache ca-certificates git \
-    && wget -q https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/${GOARCH}/kubectl -O /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl
+    go build -o /go/bin/botkube ./cmd/botkube && \
+    apk add --no-cache ca-certificates git && \
+    VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) && \
+    wget -q "https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/${GOARCH}/kubectl" -O /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
 
 # Production image
 FROM alpine:3.10
@@ -55,8 +57,8 @@ RUN addgroup --gid 101 botkube && \
 # Run as Non Privilaged user
 USER botkube
 
-COPY --from=BUILD-ENV /go/bin/botkube /go/bin/botkube
-COPY --from=BUILD-ENV /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=BUILD-ENV /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=build /go/bin/botkube /go/bin/botkube
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /usr/local/bin/kubectl /usr/local/bin/kubectl
 
 ENTRYPOINT /go/bin/botkube

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -20,8 +20,7 @@
 # Development image
 FROM golang:1.12-alpine3.10 AS BUILD-ENV
 
-ARG GOOS_VAL 
-ARG GOARCH_VAL
+ARG TARGETPLATFORM
 
 # Add git
 RUN apk update && apk add git curl
@@ -36,11 +35,14 @@ RUN go mod download
 COPY . .
 
 # Build binary
-RUN GOOS=${GOOS_VAL} GOARCH=${GOARCH_VAL} go build -o /go/bin/botkube ./cmd/botkube 
+RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
+    export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
+    GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3); export GOARM=${GOARM:1} && \
+    go build -o /go/bin/botkube ./cmd/botkube
 
 # Install kubectl binary
 RUN apk add --no-cache ca-certificates git \
-    && wget -q https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+    && wget -q https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/${GOARCH}/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
 # Production image


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

##### ISSUE TYPE 
Feature Pull Request: Adding multi-architecture support for ARM/ARM64/AMD64
Note: AMD64 was default supported architecture.

##### SUMMARY
I've implemented `docker buildx` to compile multi-architecture platforms for ARM/ARM64. This required the Dockerfile to be updated although it should not break existing functionality with previous Makefile commands due to `ARG TARGETPLATFORM` which is a native docker ARG which will still default to ARM64 if not using the `buildx` CLI. Also updated the travis workflow to push both dev images and release images, updating the dev tags with the git short sha.

https://github.com/raspbernetes/multi-arch-images/issues/77
