### PR TITLE
Enable auto merge using Mergify on approval

### DIFF
--- a/pkg/.mergify.yml
+++ b/pkg/.mergify.yml
@@ -1,0 +1,13 @@
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - base=master
+      - "#approved-reviews-by>=1"
+      - label=ready-to-merge
+      - label!=hold-off-merging
+      - status-success=continuous-integration/travis-ci/pr
+    actions:
+      merge:
+        method: squash
+        commit_message: title+body
+        strict: smart


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### SUMMARY

Enable auto merge using Mergify on approval
Workflow:
- Developer opens a PR
- Reviewer approves the changes and adds `ready-to-merge` label
- Mergify runs CI again and merges the PR
- Mergify holds the auto merge if `hold-off-merging` label is set

