### PR TITLE
add tolerations in the deployment.yaml template

### DIFF
--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -72,3 +72,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently, even if I set toleration values in the `values.yaml` file they are not being picked up as there is no toleration's block in `deployment.yaml` template, so adding the toleration's block.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->
Tested as below:
` helm template --name botkube .`

```
      volumes:
        - name: config-volume
          projected:
            sources:
            - configMap:
                name: botkube-configmap
            - secret:
                name: botkube-communication-secret
      securityContext:
        runAsUser: 101
        runAsGroup: 101
      
      tolerations:
        - effect: NoSchedule
          key: nodeType
          operator: Equal
          value: OnDemand
```

`helm3 template botkube .`
```
      volumes:
        - name: config-volume
          projected:
            sources:
            - configMap:
                name: botkube-configmap
            - secret:
                name: botkube-communication-secret
      securityContext:
        runAsUser: 101
        runAsGroup: 101
      
      tolerations:
        - effect: NoSchedule
          key: nodeType
          operator: Equal
          value: OnDemand
```