### PR TITLE
allow using AWS role or EC2 Instance role for Elasticsearch Auth

### DIFF
--- a/comm_config.yaml
+++ b/comm_config.yaml
@@ -20,10 +20,11 @@ communications:
   elasticsearch:
     enabled: false
     awsSigning:
-      enabled: false                             # enable awsSigning using IAM for Elastisearch hosted on AWS, if true make sure AWS environment variables are set. Refer https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-      awsRegion: "us-east-1"                     # AWS region where Elasticsearch is deployed
-    server: 'ELASTICSEARCH_ADDRESS'                                    # e.g https://example.com:9243
-    username: 'ELASTICSEARCH_USERNAME'                                 # Basic Auth
+      enabled: false                            # enable awsSigning using IAM for Elastisearch hosted on AWS, if true make sure AWS environment variables are set. Refer https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+      awsRegion: 'us-east-1'                    # AWS region where Elasticsearch is deployed
+      roleArn: ''                               # AWS IAM Role arn to assume for credentials, use this only if you dont want to use the EC2 instance role or not running on AWS instance
+    server: 'ELASTICSEARCH_ADDRESS'             # e.g https://example.com:9243
+    username: 'ELASTICSEARCH_USERNAME'          # Basic Auth
     password: 'ELASTICSEARCH_PASSWORD'
     # ELS index settings
     index:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -128,6 +128,7 @@ type ElasticSearch struct {
 type AWSSigning struct {
 	Enabled   bool
 	AWSRegion string `yaml:"awsRegion"`
+	RoleArn   string `yaml:"roleArn"`
 }
 
 // Index settings for ELS


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allow using AWS role or EC2 Instance role to generate session tokens for AWS credentials.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->
