### PR TITLE
Refactor notifier to use Bot interface to send notifications

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,7 @@ github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tF
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-redis/redis v6.15.2+incompatible h1:9SpNVG76gr6InJGxoZ6IuuxaCOQwDAhzyXg+Bs+0Sb4=
 github.com/go-redis/redis v6.15.2+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
-github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
-github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -308,6 +307,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 h1:j2hhcujLRHAg872RWAV5yaUrEjHEObwDv3aImCaNLek=
@@ -352,8 +352,6 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191009170851-d66e71096ffb h1:TR699M2v0qoKTOHxeLgp6zPqaQNs74f01a/ob9W0qko=
-golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,7 @@ type Config struct {
 	Settings        Settings
 }
 
+// Communications contains communication config
 type Communications struct {
 	Communications CommunicationsConfig
 }
@@ -199,6 +200,7 @@ func (eventType EventType) String() string {
 	return string(eventType)
 }
 
+// NewCommunicationsConfig return new communication config object
 func NewCommunicationsConfig() (*Communications, error) {
 	c := &Communications{}
 	configPath := os.Getenv("CONFIG_PATH")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,10 +48,24 @@ const (
 	ShortNotify NotifType = "short"
 	// LongNotify for short events notification
 	LongNotify NotifType = "long"
+
+	// Info level
+	Info Level = "info"
+	// Warn level
+	Warn Level = "warn"
+	// Debug level
+	Debug Level = "debug"
+	// Error level
+	Error Level = "error"
+	// Critical level
+	Critical Level = "critical"
 )
 
 // EventType to watch
 type EventType string
+
+// Level type to store event levels
+type Level string
 
 // ResourceConfigFileName is a name of botkube resource configuration file
 var ResourceConfigFileName = "resource_config.yaml"
@@ -69,8 +83,12 @@ type NotifType string
 type Config struct {
 	Resources       []Resource
 	Recommendations bool
-	Communications  Communications
+	Communications  CommunicationsConfig
 	Settings        Settings
+}
+
+type Communications struct {
+	Communications CommunicationsConfig
 }
 
 // Resource contains resources to watch
@@ -98,8 +116,8 @@ type Namespaces struct {
 	Ignore  []string `yaml:",omitempty"`
 }
 
-// Communications channels to send events to
-type Communications struct {
+// CommunicationsConfig channels to send events to
+type CommunicationsConfig struct {
 	Slack         Slack
 	ElasticSearch ElasticSearch
 	Mattermost    Mattermost
@@ -181,6 +199,27 @@ func (eventType EventType) String() string {
 	return string(eventType)
 }
 
+func NewCommunicationsConfig() (*Communications, error) {
+	c := &Communications{}
+	configPath := os.Getenv("CONFIG_PATH")
+	communicationConfigFilePath := filepath.Join(configPath, CommunicationConfigFileName)
+	communicationConfigFile, err := os.Open(communicationConfigFilePath)
+	defer communicationConfigFile.Close()
+	if err != nil {
+		return c, err
+	}
+
+	b, err := ioutil.ReadAll(communicationConfigFile)
+	if err != nil {
+		return c, err
+	}
+
+	if len(b) != 0 {
+		yaml.Unmarshal(b, c)
+	}
+	return c, nil
+}
+
 // New returns new Config
 func New() (*Config, error) {
 	c := &Config{}
@@ -201,20 +240,11 @@ func New() (*Config, error) {
 		yaml.Unmarshal(b, c)
 	}
 
-	communicationConfigFilePath := filepath.Join(configPath, CommunicationConfigFileName)
-	communicationConfigFile, err := os.Open(communicationConfigFilePath)
-	defer communicationConfigFile.Close()
+	comm, err := NewCommunicationsConfig()
 	if err != nil {
-		return c, err
+		return nil, err
 	}
+	c.Communications = comm.Communications
 
-	b, err = ioutil.ReadAll(communicationConfigFile)
-	if err != nil {
-		return c, err
-	}
-
-	if len(b) != 0 {
-		yaml.Unmarshal(b, c)
-	}
 	return c, nil
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -33,22 +33,6 @@ import (
 	rbacV1 "k8s.io/api/rbac/v1"
 )
 
-// Level type to store event levels
-type Level string
-
-const (
-	// Info level
-	Info Level = "info"
-	// Warn level
-	Warn Level = "warn"
-	// Debug level
-	Debug Level = "debug"
-	// Error level
-	Error Level = "error"
-	// Critical level
-	Critical Level = "critical"
-)
-
 // Event to store required information from k8s objects
 type Event struct {
 	Code      string
@@ -60,7 +44,7 @@ type Event struct {
 	Type      config.EventType
 	Reason    string
 	Error     string
-	Level     Level
+	Level     config.Level
 	Cluster   string
 	Channel   string
 	TimeStamp time.Time
@@ -73,15 +57,15 @@ type Event struct {
 }
 
 // LevelMap is a map of event type to Level
-var LevelMap map[config.EventType]Level
+var LevelMap map[config.EventType]config.Level
 
 func init() {
-	LevelMap = make(map[config.EventType]Level)
-	LevelMap[config.CreateEvent] = Info
-	LevelMap[config.UpdateEvent] = Warn
-	LevelMap[config.DeleteEvent] = Critical
-	LevelMap[config.ErrorEvent] = Error
-	LevelMap[config.WarningEvent] = Error
+	LevelMap = make(map[config.EventType]config.Level)
+	LevelMap[config.CreateEvent] = config.Info
+	LevelMap[config.UpdateEvent] = config.Warn
+	LevelMap[config.DeleteEvent] = config.Critical
+	LevelMap[config.ErrorEvent] = config.Error
+	LevelMap[config.WarningEvent] = config.Error
 }
 
 // New extract required details from k8s object and returns new Event object

--- a/pkg/filterengine/filters/node_event_checker.go
+++ b/pkg/filterengine/filters/node_event_checker.go
@@ -68,10 +68,10 @@ func (f NodeEventsChecker) Run(object interface{}, event *events.Event) {
 	switch event.Reason {
 	case NodeNotReady:
 		event.Type = config.ErrorEvent
-		event.Level = events.Critical
+		event.Level = config.Critical
 	case NodeReady:
 		event.Type = config.InfoEvent
-		event.Level = events.Info
+		event.Level = config.Info
 	default:
 		// skip events with least significant reasons
 		event.Skip = true

--- a/pkg/notify/mattermost.go
+++ b/pkg/notify/mattermost.go
@@ -38,15 +38,15 @@ type Mattermost struct {
 }
 
 // NewMattermost returns new Mattermost object
-func NewMattermost(c *config.Config) (Notifier, error) {
+func NewMattermost(c config.Mattermost) (Notifier, error) {
 	// Set configurations for Mattermost server
-	client := model.NewAPIv4Client(c.Communications.Mattermost.URL)
-	client.SetOAuthToken(c.Communications.Mattermost.Token)
-	botTeam, resp := client.GetTeamByName(c.Communications.Mattermost.Team, "")
+	client := model.NewAPIv4Client(c.URL)
+	client.SetOAuthToken(c.Token)
+	botTeam, resp := client.GetTeamByName(c.Team, "")
 	if resp.Error != nil {
 		return nil, resp.Error
 	}
-	botChannel, resp := client.GetChannelByName(c.Communications.Mattermost.Channel, botTeam.Id, "")
+	botChannel, resp := client.GetChannelByName(c.Channel, botTeam.Id, "")
 	if resp.Error != nil {
 		return nil, resp.Error
 	}
@@ -54,7 +54,7 @@ func NewMattermost(c *config.Config) (Notifier, error) {
 	return &Mattermost{
 		Client:    client,
 		Channel:   botChannel.Id,
-		NotifType: c.Communications.Mattermost.NotifType,
+		NotifType: c.NotifType,
 	}, nil
 }
 

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -33,6 +33,7 @@ type Notifier interface {
 	SendMessage(string) error
 }
 
+// ListNotifiers returns list of configured notifiers
 func ListNotifiers(conf config.CommunicationsConfig) []Notifier {
 	var notifiers []Notifier
 	if conf.Slack.Enabled {

--- a/pkg/notify/slack.go
+++ b/pkg/notify/slack.go
@@ -30,44 +30,38 @@ import (
 	"github.com/nlopes/slack"
 )
 
-var attachmentColor = map[events.Level]string{
-	events.Info:     "good",
-	events.Warn:     "warning",
-	events.Debug:    "good",
-	events.Error:    "danger",
-	events.Critical: "danger",
+var attachmentColor = map[config.Level]string{
+	config.Info:     "good",
+	config.Warn:     "warning",
+	config.Debug:    "good",
+	config.Error:    "danger",
+	config.Critical: "danger",
 }
 
 // Slack contains Token for authentication with slack and Channel name to send notification to
 type Slack struct {
-	Token     string
 	Channel   string
 	NotifType config.NotifType
-	SlackURL  string // Useful only for testing
+	Client    *slack.Client
 }
 
 // NewSlack returns new Slack object
-func NewSlack(c *config.Config) Notifier {
+func NewSlack(c config.Slack) Notifier {
 	return &Slack{
-		Token:     c.Communications.Slack.Token,
-		Channel:   c.Communications.Slack.Channel,
-		NotifType: c.Communications.Slack.NotifType,
+		Channel:   c.Channel,
+		NotifType: c.NotifType,
+		Client:    slack.New(c.Token),
 	}
 }
 
 // SendEvent sends event notification to slack
 func (s *Slack) SendEvent(event events.Event) error {
 	log.Debug(fmt.Sprintf(">> Sending to slack: %+v", event))
-
-	api := slack.New(s.Token)
-	if len(s.SlackURL) != 0 {
-		api = slack.New(s.Token, slack.OptionAPIURL(s.SlackURL))
-	}
 	attachment := formatSlackMessage(event, s.NotifType)
 
 	// non empty value in event.channel demands redirection of events to a different channel
 	if event.Channel != "" {
-		channelID, timestamp, err := api.PostMessage(event.Channel, slack.MsgOptionAttachments(attachment), slack.MsgOptionAsUser(true))
+		channelID, timestamp, err := s.Client.PostMessage(event.Channel, slack.MsgOptionAttachments(attachment), slack.MsgOptionAsUser(true))
 		if err != nil {
 			log.Errorf("Error in sending slack message %s", err.Error())
 			// send error message to default channel
@@ -84,7 +78,7 @@ func (s *Slack) SendEvent(event events.Event) error {
 		log.Debugf("Event successfully sent to channel %s at %s", channelID, timestamp)
 	} else {
 		// empty value in event.channel sends notifications to default channel.
-		channelID, timestamp, err := api.PostMessage(s.Channel, slack.MsgOptionAttachments(attachment), slack.MsgOptionAsUser(true))
+		channelID, timestamp, err := s.Client.PostMessage(s.Channel, slack.MsgOptionAttachments(attachment), slack.MsgOptionAsUser(true))
 		if err != nil {
 			log.Errorf("Error in sending slack message %s", err.Error())
 			return err
@@ -98,12 +92,12 @@ func (s *Slack) SendEvent(event events.Event) error {
 func (s *Slack) SendMessage(msg string) error {
 	log.Debug(fmt.Sprintf(">> Sending to slack: %+v", msg))
 
-	api := slack.New(s.Token)
-	if len(s.SlackURL) != 0 {
-		api = slack.New(s.Token, slack.OptionAPIURL(s.SlackURL))
-	}
+	//api := slack.New(s.Token)
+	//if len(s.SlackURL) != 0 {
+	//	api = slack.New(s.Token, slack.OptionAPIURL(s.SlackURL))
+	//}
 
-	channelID, timestamp, err := api.PostMessage(s.Channel, slack.MsgOptionText(msg, false), slack.MsgOptionAsUser(true))
+	channelID, timestamp, err := s.Client.PostMessage(s.Channel, slack.MsgOptionText(msg, false), slack.MsgOptionAsUser(true))
 	if err != nil {
 		log.Errorf("Error in sending slack message %s", err.Error())
 		return err

--- a/pkg/notify/slack.go
+++ b/pkg/notify/slack.go
@@ -91,12 +91,6 @@ func (s *Slack) SendEvent(event events.Event) error {
 // SendMessage sends message to slack channel
 func (s *Slack) SendMessage(msg string) error {
 	log.Debug(fmt.Sprintf(">> Sending to slack: %+v", msg))
-
-	//api := slack.New(s.Token)
-	//if len(s.SlackURL) != 0 {
-	//	api = slack.New(s.Token, slack.OptionAPIURL(s.SlackURL))
-	//}
-
 	channelID, timestamp, err := s.Client.PostMessage(s.Channel, slack.MsgOptionText(msg, false), slack.MsgOptionAsUser(true))
 	if err != nil {
 		log.Errorf("Error in sending slack message %s", err.Error())

--- a/pkg/notify/webhook.go
+++ b/pkg/notify/webhook.go
@@ -31,10 +31,9 @@ import (
 	"github.com/infracloudio/botkube/pkg/log"
 )
 
-// Webhook contains URL and ClusterName
+// Webhook contains URL
 type Webhook struct {
-	URL         string
-	ClusterName string
+	URL string
 }
 
 // WebhookPayload contains json payload to be sent to webhook url
@@ -58,26 +57,21 @@ type EventMeta struct {
 // EventStatus contains the status about the event occurred
 type EventStatus struct {
 	Type     config.EventType `json:"type"`
-	Level    events.Level     `json:"level"`
+	Level    config.Level     `json:"level"`
 	Reason   string           `json:"reason,omitempty"`
 	Error    string           `json:"error,omitempty"`
 	Messages []string         `json:"messages,omitempty"`
 }
 
 // NewWebhook returns new Webhook object
-func NewWebhook(c *config.Config) Notifier {
+func NewWebhook(c config.CommunicationsConfig) Notifier {
 	return &Webhook{
-		URL:         c.Communications.Webhook.URL,
-		ClusterName: c.Settings.ClusterName,
+		URL: c.Webhook.URL,
 	}
 }
 
 // SendEvent sends event notification to Webhook url
 func (w *Webhook) SendEvent(event events.Event) (err error) {
-
-	// set missing cluster name to event object
-	event.Cluster = w.ClusterName
-
 	jsonPayload := &WebhookPayload{
 		EventMeta: EventMeta{
 			Kind:      event.Kind,

--- a/pkg/notify/webhook_test.go
+++ b/pkg/notify/webhook_test.go
@@ -54,8 +54,7 @@ func TestPostWebhook(t *testing.T) {
 			defer ts.Close()
 			// create a dummy webhook object to test
 			w := &Webhook{
-				URL:         ts.URL,
-				ClusterName: "test",
+				URL: ts.URL,
 			}
 
 			err := w.PostWebhook(&WebhookPayload{})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nlopes/slack"
+
 	"github.com/infracloudio/botkube/pkg/bot"
 	"github.com/infracloudio/botkube/pkg/controller"
 	"github.com/infracloudio/botkube/pkg/notify"
@@ -45,10 +47,9 @@ func TestRun(t *testing.T) {
 
 	if testEnv.Config.Communications.Slack.Enabled {
 		fakeSlackNotifier := &notify.Slack{
-			Token:     testEnv.Config.Communications.Slack.Token,
 			Channel:   testEnv.Config.Communications.Slack.Channel,
 			NotifType: testEnv.Config.Communications.Slack.NotifType,
-			SlackURL:  testEnv.SlackServer.GetAPIURL(),
+			Client:    slack.New(testEnv.Config.Communications.Slack.Token, slack.OptionAPIURL(testEnv.SlackServer.GetAPIURL())),
 		}
 
 		notifiers = append(notifiers, fakeSlackNotifier)
@@ -56,8 +57,7 @@ func TestRun(t *testing.T) {
 
 	if testEnv.Config.Communications.Webhook.Enabled {
 		fakeWebhookNotifier := &notify.Webhook{
-			URL:         testEnv.WebhookServer.GetAPIURL(),
-			ClusterName: testEnv.Config.Settings.ClusterName,
+			URL: testEnv.WebhookServer.GetAPIURL(),
 		}
 		notifiers = append(notifiers, fakeWebhookNotifier)
 	}

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -22,13 +22,14 @@ package utils
 import (
 	"testing"
 
-	"github.com/infracloudio/botkube/pkg/config"
-	"github.com/infracloudio/botkube/pkg/notify"
-	"github.com/infracloudio/botkube/pkg/utils"
 	"github.com/nlopes/slack"
 	v1 "k8s.io/api/core/v1"
 	networkV1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/notify"
+	"github.com/infracloudio/botkube/pkg/utils"
 )
 
 // SlackMessage structure


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### SUMMARY

In the notifier, we send events by creating a new connection to the communication medium on every new event. We can reduce the number of connections by sending messages via the Bot interface.

Fixes #270 
