### PR TITLE
Fix crash on empty command in mattermost integration

### DIFF
--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -169,7 +169,11 @@ func NewDefaultExecutor(msg string, allowkubectl, restrictAccess bool, defaultNa
 func (e *DefaultExecutor) Execute() string {
 	args := strings.Fields(e.Message)
 	if len(args) == 0 {
-		return printDefaultMsg(e.Platform)
+		if e.IsAuthChannel {
+			return printDefaultMsg(e.Platform)
+		} else {
+			return ""
+		}
 	}
 	if len(args) >= 1 && utils.AllowedKubectlVerbMap[args[0]] {
 		if validDebugCommands[args[0]] || // Don't check for resource if is a valid debug command

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -168,7 +168,9 @@ func NewDefaultExecutor(msg string, allowkubectl, restrictAccess bool, defaultNa
 // Execute executes commands and returns output
 func (e *DefaultExecutor) Execute() string {
 	args := strings.Fields(e.Message)
-
+	if len(args) == 0 {
+		return printDefaultMsg(e.Platform)
+	}
 	if len(args) >= 1 && utils.AllowedKubectlVerbMap[args[0]] {
 		if validDebugCommands[args[0]] || // Don't check for resource if is a valid debug command
 			utils.AllowedKubectlResourceMap[args[1]] || // Check if allowed resource

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -171,9 +171,8 @@ func (e *DefaultExecutor) Execute() string {
 	if len(args) == 0 {
 		if e.IsAuthChannel {
 			return printDefaultMsg(e.Platform)
-		} else {
-			return ""
 		}
+		return ""
 	}
 	if len(args) >= 1 && utils.AllowedKubectlVerbMap[args[0]] {
 		if validDebugCommands[args[0]] || // Don't check for resource if is a valid debug command


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY
This should fix panic on empty command. 
Bot will send the default message for the executor Platform (in my case its mattermost)

##### What did you do?
Sent empty command to botkube via mattermost (type @botkube)
##### What did you expect to see?

> Command not supported. Please run /botkubehelp to see supported commands.

or at least nothing 

##### What did you see? 
`panic: runtime error: index out of range [0] with length 0
goroutine 28 [running]:
github.com/infracloudio/botkube/pkg/execute.(*DefaultExecutor).Execute(0xc000a11020, 0x0, 0x0)
        go/src/github.com/gohumble/botkube/pkg/execute/executor.go:191 +0xe13
github.com/infracloudio/botkube/pkg/bot.(*mattermostMessage).handleMessage(0xc000b75de8, 0xc0003d1940, 0x1a, 0xc00046b7c0, 0x5, 0xc00046b7cc, 0x4, 0xc00046b120, 0xd, 0x1, ...)
        go/src/github.com/gohumble/botkube/pkg/bot/mattermost.go:154 +0x54e
github.com/infracloudio/botkube/pkg/bot.MMBot.listen(0xc0003d1940, 0x1a, 0xc00046b7c0, 0x5, 0xc00046b7cc, 0x4, 0xc00046b120, 0xd, 0x1, 0xc0003d1880, ...)
        go/src/github.com/gohumble/botkube/pkg/bot/mattermost.go:253 +0x4d1
github.com/infracloudio/botkube/pkg/bot.(*MMBot).Start.func1(0xc00058f4d0)
        go/src/github.com/gohumble/botkube/pkg/bot/mattermost.go:125 +0x2c7
created by github.com/infracloudio/botkube/pkg/bot.(*MMBot).Start
        src/github.com/gohumble/botkube/pkg/bot/mattermost.go:113 +0x712
Exiting.`
