### PR TITLE
Added '@Botkube commands list' to show all the supported kubectl cmds 

### DIFF
--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -81,9 +81,6 @@ const (
 	// IncompleteCmdMsg incomplete command response message
 	IncompleteCmdMsg = "You missed to pass options for the command. Please run /botkubehelp to see command options."
 
-	//IncompleteInfoCmdMsg incomplete command response message
-	IncompleteInfoCmdMsg = "You missed to pass correct option i.e. list"
-
 	// Custom messages for teams platform
 	teamsUnsupportedCmdMsg = "Command not supported. Please visit botkube.io/usage to see supported commands."
 	teamsIncompleteCmdMsg  = "You missed to pass options for the command. Please run /botkubehelp to see command options."
@@ -381,26 +378,15 @@ func (e *DefaultExecutor) runInfoCommand(args []string, isAuthChannel bool) stri
 		return ""
 	}
 	if len(args) < 2 && args[1] != string(InfoList) {
-		return IncompleteInfoCmdMsg
+		return IncompleteCmdMsg
 	}
 	return makeCommandInfoList()
 }
 
 func makeCommandInfoList() string {
-	var b strings.Builder
-	fmt.Fprintln(&b, "allowed verbs:")
-	for k, v := range utils.AllowedKubectlVerbMap {
-		if v {
-			fmt.Fprintf(&b, "- %s\n", k)
-		}
-	}
-	fmt.Fprintln(&b, "allowed resources:")
-	for k, v := range utils.AllowedKubectlResourceMap {
-		if v {
-			fmt.Fprintf(&b, "- %s\n", k)
-		}
-	}
-	return b.String()
+	allowedVerbs := utils.GetFormatedCommandsList("allowed verbs:", utils.AllowedKubectlVerbMap)
+	allowedResources := utils.GetFormatedCommandsList("allowed resources:", utils.AllowedKubectlResourceMap)
+	return allowedVerbs + allowedResources
 }
 
 // Use tabwriter to display string in tabular form

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -149,12 +149,12 @@ const (
 	FilterDisable FiltersAction = "disable"
 )
 
-// InfoAction for options in Info commands
-type InfoAction string
+// infoAction for options in Info commands
+type infoAction string
 
 // Info command options
 const (
-	InfoList InfoAction = "list"
+	InfoList infoAction = "list"
 )
 
 func (action FiltersAction) String() string {
@@ -389,8 +389,8 @@ func (e *DefaultExecutor) runInfoCommand(args []string, isAuthChannel bool) stri
 }
 
 func makeCommandInfoList() string {
-	allowedVerbs := utils.GetFormatedCommandsList("allowed verbs:", utils.AllowedKubectlVerbMap)
-	allowedResources := utils.GetFormatedCommandsList("allowed resources:", utils.AllowedKubectlResourceMap)
+	allowedVerbs := utils.GetStingInYamlFormat("allowed verbs:", utils.AllowedKubectlVerbMap)
+	allowedResources := utils.GetStingInYamlFormat("allowed resources:", utils.AllowedKubectlResourceMap)
 	return allowedVerbs + allowedResources
 }
 

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -389,8 +389,8 @@ func (e *DefaultExecutor) runInfoCommand(args []string, isAuthChannel bool) stri
 }
 
 func makeCommandInfoList() string {
-	allowedVerbs := utils.GetStingInYamlFormat("allowed verbs:", utils.AllowedKubectlVerbMap)
-	allowedResources := utils.GetStingInYamlFormat("allowed resources:", utils.AllowedKubectlResourceMap)
+	allowedVerbs := utils.GetStringInYamlFormat("allowed verbs:", utils.AllowedKubectlVerbMap)
+	allowedResources := utils.GetStringInYamlFormat("allowed resources:", utils.AllowedKubectlResourceMap)
 	return allowedVerbs + allowedResources
 }
 

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -154,7 +154,7 @@ type infoAction string
 
 // Info command options
 const (
-	InfoList infoAction = "list"
+	infoList infoAction = "list"
 )
 
 func (action FiltersAction) String() string {
@@ -382,7 +382,7 @@ func (e *DefaultExecutor) runInfoCommand(args []string, isAuthChannel bool) stri
 	if isAuthChannel == false {
 		return ""
 	}
-	if len(args) < 2 && args[1] != string(InfoList) {
+	if len(args) < 2 && args[1] != string(infoList) {
 		return IncompleteCmdMsg
 	}
 	return makeCommandInfoList()

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -480,8 +480,8 @@ func GetClusterNameFromKubectlCmd(cmd string) string {
 	return s
 }
 
-//GetFormatedCommandsList get the formated commands list
-func GetFormatedCommandsList(header string, commands map[string]bool) string {
+//GetStingInYamlFormat get the formated commands list
+func GetStingInYamlFormat(header string, commands map[string]bool) string {
 	var b bytes.Buffer
 	fmt.Fprintln(&b, header)
 	for k, v := range commands {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -480,8 +480,8 @@ func GetClusterNameFromKubectlCmd(cmd string) string {
 	return s
 }
 
-//GetStingInYamlFormat get the formated commands list
-func GetStingInYamlFormat(header string, commands map[string]bool) string {
+//GetStringInYamlFormat get the formated commands list
+func GetStringInYamlFormat(header string, commands map[string]bool) string {
 	var b bytes.Buffer
 	fmt.Fprintln(&b, header)
 	for k, v := range commands {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -480,7 +480,7 @@ func GetClusterNameFromKubectlCmd(cmd string) string {
 	return s
 }
 
-//Get the formated commands list
+//GetFormatedCommandsList get the formated commands list
 func GetFormatedCommandsList(header string, commands map[string]bool) string {
 	var b bytes.Buffer
 	fmt.Fprintln(&b, header)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,6 +20,8 @@
 package utils
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"regexp"
 	"strconv"
@@ -476,4 +478,16 @@ func GetClusterNameFromKubectlCmd(cmd string) string {
 		s = matchedArray[1]
 	}
 	return s
+}
+
+//Get the formated commands list
+func GetFormatedCommandsList(header string, commands map[string]bool) string {
+	var b bytes.Buffer
+	fmt.Fprintln(&b, header)
+	for k, v := range commands {
+		if v {
+			fmt.Fprintf(&b, "  - %s\n", k)
+		}
+	}
+	return b.String()
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,6 +20,7 @@
 package utils
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -47,5 +48,17 @@ func TestGetClusterNameFromKubectlCmd(t *testing.T) {
 		if got != ts.expected {
 			t.Errorf("expected: %v, got: %v", ts.expected, got)
 		}
+	}
+}
+
+func TestGetFormatedCommandsList(t *testing.T) {
+	var header = "allowed verbs"
+	var commands = map[string]bool{
+		"api-versions": true,
+	}
+	expected := fmt.Sprintf(header + "\n  - api-versions\n")
+	got := GetFormatedCommandsList(header, commands)
+	if got != expected {
+		t.Errorf("expected: %v, got: %v", expected, got)
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -51,13 +51,13 @@ func TestGetClusterNameFromKubectlCmd(t *testing.T) {
 	}
 }
 
-func TestGetFormatedCommandsList(t *testing.T) {
+func TestGetStingInYamlFormat(t *testing.T) {
 	var header = "allowed verbs"
 	var commands = map[string]bool{
 		"api-versions": true,
 	}
 	expected := fmt.Sprintf(header + "\n  - api-versions\n")
-	got := GetFormatedCommandsList(header, commands)
+	got := GetStingInYamlFormat(header, commands)
 	if got != expected {
 		t.Errorf("expected: %v, got: %v", expected, got)
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -51,13 +51,13 @@ func TestGetClusterNameFromKubectlCmd(t *testing.T) {
 	}
 }
 
-func TestGetStingInYamlFormat(t *testing.T) {
+func TestGetStringInYamlFormat(t *testing.T) {
 	var header = "allowed verbs"
 	var commands = map[string]bool{
 		"api-versions": true,
 	}
 	expected := fmt.Sprintf(header + "\n  - api-versions\n")
-	got := GetStingInYamlFormat(header, commands)
+	got := GetStringInYamlFormat(header, commands)
 	if got != expected {
 		t.Errorf("expected: %v, got: %v", expected, got)
 	}

--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -59,8 +59,29 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 				"ImageTagChecker         true    Checks and adds recommendation if 'latest' image tag is used for container image.\n" +
 				"IngressValidator        true    Checks if services and tls secrets used in ingress specs are available.\n",
 		},
+		"BotKube commands list": {
+			command: "commands list",
+			expected: "allowed verbs:\n" +
+				"  - api-resources\n" +
+				"  - describe\n" +
+				"  - diff\n" +
+				"  - explain\n" +
+				"  - get\n" +
+				"  - logs\n" +
+				"  - api-versions\n" +
+				"  - cluster-info\n" +
+				"  - top\n" +
+				"  - auth\n" +
+				"allowed resources:\n" +
+				"  - nodes\n" +
+				"  - deployments\n" +
+				"  - pods\n" +
+				"  - namespaces\n" +
+				"  - daemonsets\n" +
+				"  - statefulsets\n" +
+				"  - storageclasses\n",
+		},
 	}
-
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			if c.TestEnv.Config.Communications.Slack.Enabled {
@@ -80,6 +101,9 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 				case "filters list":
 					fl := compareFilters(strings.Split(test.expected, "\n"), strings.Split(strings.Trim(m.Text, "```"), "\n"))
 					assert.Equal(t, fl, true)
+				case "commands list":
+					cl := compareFilters(strings.Split(test.expected, "\n"), strings.Split(strings.Trim(m.Text, "```"), "\n"))
+					assert.Equal(t, cl, true)
 				default:
 					assert.Equal(t, test.expected, m.Text)
 				}

--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/infracloudio/botkube/pkg/config"
 	"github.com/infracloudio/botkube/pkg/execute"
+	"github.com/infracloudio/botkube/pkg/log"
 	"github.com/infracloudio/botkube/test/e2e/utils"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
@@ -114,6 +115,7 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 
 func compareFilters(expected, actual []string) bool {
 	if len(expected) != len(actual) {
+		log.Infof("************************Expected %d Actual %d", len(expected), len(actual))
 		return false
 	}
 
@@ -127,6 +129,7 @@ func compareFilters(expected, actual []string) bool {
 			}
 		}
 		if !found {
+			log.Infof("************************Not Found %s", a)
 			return false
 		}
 	}

--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/infracloudio/botkube/pkg/config"
 	"github.com/infracloudio/botkube/pkg/execute"
-	"github.com/infracloudio/botkube/pkg/log"
 	"github.com/infracloudio/botkube/test/e2e/utils"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
@@ -115,7 +114,6 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 
 func compareFilters(expected, actual []string) bool {
 	if len(expected) != len(actual) {
-		log.Infof("************************Expected %d Actual %d", len(expected), len(actual))
 		return false
 	}
 
@@ -129,7 +127,6 @@ func compareFilters(expected, actual []string) bool {
 			}
 		}
 		if !found {
-			log.Infof("************************Not Found %s", a)
 			return false
 		}
 	}

--- a/test/resource_config.yaml
+++ b/test/resource_config.yaml
@@ -212,7 +212,8 @@ settings:
       # method which are allowed
       verbs: ["api-resources", "api-versions", "cluster-info", "describe", "diff", "explain", "get", "logs", "top", "auth"]
       # resource configuration which is allowed
-      resources: ["deployments", "pods" , "namespaces", "daemonsets", "statefulsets", "storageclasses", "serviceaccounts"]
+      resources: ["deployments", "pods" , "namespaces", "daemonsets", "statefulsets", "storageclasses", "nodes"]
+
     # set Namespace to execute botkube kubectl commands by default
     defaultNamespace: default
     # Set true to enable commands execution from configured channel only


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Added new botkube command to list all the supported commands, @botkube commands list

Below are the changes
made changes in executor.go to handle newly added command  
added common method in utils.go to format the allowed commands  

Fixes https://github.com/infracloudio/botkube/issues/312
