### PR TITLE
Fix for missing update diff for first update event

### DIFF
--- a/pkg/utils/diff.go
+++ b/pkg/utils/diff.go
@@ -33,14 +33,13 @@ type diffReporter struct {
 func (d diffReporter) exec(x, y interface{}) (string, bool) {
 	vx, err := parseJsonpath(x, d.field)
 	if err != nil {
+		// Happens when the fields were not set by the time event was issued, do not return in that case
 		log.Debugf("Failed to find value from jsonpath: %s, object: %+v. Error: %v", d.field, x, err)
-		return "", false
 	}
 
 	vy, err := parseJsonpath(y, d.field)
 	if err != nil {
 		log.Debugf("Failed to find value from jsonpath: %s, object: %+v, Error: %v", d.field, y, err)
-		return "", false
 	}
 
 	// treat <none> and false as same fields


### PR DESCRIPTION

##### ISSUE TYPE

 - Bug fix Pull Request

##### SUMMARY

Jsonpath eval fails if fields are not set in old obj by the time event issued. Ignore error in that case and continue message construction
