### PR TITLE
Add e2e test for executing kubectl command on forbidden verbs and resources

### DIFF
--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -83,6 +83,10 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 				"  - statefulsets\n" +
 				"  - storageclasses\n",
 		},
+		"BotKube notifier showconfig": {
+			command:  "notifier showconfig",
+			expected: "<@U023BECGF> notifier showconfig",
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/test/e2e/command/kubectl.go
+++ b/test/e2e/command/kubectl.go
@@ -54,6 +54,16 @@ func (c *context) testKubectlCommand(t *testing.T) {
 			expected: fmt.Sprintf("<@U023BECGF> get pods"),
 			channel:  "dummy",
 		},
+		"kubectl command on forbidden verb and resource": {
+			command:  "config set clusters.test-clustor-1.server https://1.2.3.4",
+			expected: "```Command not supported. Please run /botkubehelp to see supported commands.```",
+			channel:  c.Config.Communications.Slack.Channel,
+		},
+		"kubectl command on forbidden resource": {
+			command:  "get endpoints",
+			expected: "```Command not supported. Please run /botkubehelp to see supported commands.```",
+			channel:  c.Config.Communications.Slack.Channel,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added a e2e test kubectl command with forbidden verb and forbidden resource. Another one for kubctl command with allowed verb and forbidden resource
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

Fixes #350 
