### PR TITLE
Kubernetes: Ingress extensions/v1beta1 -> networking.k8s.io/v1beta1

### DIFF
--- a/helm/botkube/templates/ingress.yaml
+++ b/helm/botkube/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.create }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "botkube.fullname" . }}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
Resource Ingress is deprecated in Kubernetes API `extensions/v1beta1`

https://github.com/infracloudio/botkube/blob/c6db9526a3232b210fd05202d104ca18eb3a03c2/helm/botkube/templates/ingress.yaml#L2-L3

Referencing PR: [kubernetes/kubernetes#74057](https://github.com/kubernetes/kubernetes/pull/74057)

##### POSSIBLE FIX
> **apiVersion: networking.k8s.io/v1beta1**
> kind: Ingress
