### PR TITLE
added testcases for skip delete event for resources not configured

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/infracloudio/botkube/test/e2e/env"
 	"github.com/infracloudio/botkube/test/e2e/filters"
 	"github.com/infracloudio/botkube/test/e2e/notifier/create"
+	"github.com/infracloudio/botkube/test/e2e/notifier/delete"
 	"github.com/infracloudio/botkube/test/e2e/notifier/update"
 	"github.com/infracloudio/botkube/test/e2e/welcome"
 )
@@ -86,6 +87,7 @@ func TestRun(t *testing.T) {
 		"command":  command.E2ETests(testEnv),
 		"filters":  filters.E2ETests(testEnv),
 		"update":   update.E2ETests(testEnv),
+		"delete":   delete.E2ETests(testEnv),
 	}
 
 	// Run test suite

--- a/test/e2e/notifier/delete/delete.go
+++ b/test/e2e/notifier/delete/delete.go
@@ -1,0 +1,64 @@
+package delete
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/utils"
+	"github.com/infracloudio/botkube/test/e2e/env"
+	testutils "github.com/infracloudio/botkube/test/e2e/utils"
+)
+
+type context struct {
+	*env.TestEnv
+}
+
+func (c *context) testSKipDeleteEvent(t *testing.T) {
+	// Modifying AllowedEventKindsMap to remove delete event for pod resource
+	delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: "delete"})
+	// test scenarios
+	tests := map[string]testutils.DeleteObjects{
+		"skip delete event for resources not configured": {
+			// delete operation not allowed for Pod in test namespace so event should be skipped
+			GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Kind:      "Pod",
+			Namespace: "test",
+			Specs:     &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod-delete"}, Spec: v1.PodSpec{Containers: []v1.Container{{Name: "test-pod-container", Image: "tomcat:9.0.34"}}}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			resource := utils.GVRToString(test.GVR)
+			// checking if delete operation is skipped
+			isAllowed := utils.AllowedEventKindsMap[utils.EventKind{
+				Resource:  resource,
+				Namespace: "all",
+				EventType: config.DeleteEvent}] ||
+				utils.AllowedEventKindsMap[utils.EventKind{
+					Resource:  resource,
+					Namespace: test.Namespace,
+					EventType: config.DeleteEvent}]
+			assert.Equal(t, isAllowed, false)
+		})
+	}
+	// Resetting original configuration as per test_config
+	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: "delete"}] = true
+}
+
+// Run tests
+func (c *context) Run(t *testing.T) {
+	t.Run("delete resource", c.testSKipDeleteEvent)
+}
+
+// E2ETests runs delete notification tests
+func E2ETests(testEnv *env.TestEnv) env.E2ETest {
+	return &context{
+		testEnv,
+	}
+}

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -58,7 +58,7 @@ type CreateObjects struct {
 	ExpectedSlackMessage   SlackMessage
 }
 
-//UpdateObjects stores specs and patch for updating a k8s fake object and expected Slack response
+// UpdateObjects stores specs and patch for updating a k8s fake object and expected Slack response
 type UpdateObjects struct {
 	GVR                    schema.GroupVersionResource
 	Kind                   string
@@ -71,6 +71,15 @@ type UpdateObjects struct {
 	NotifType              config.NotifType
 	ExpectedWebhookPayload WebhookPayload
 	ExpectedSlackMessage   SlackMessage
+}
+
+// DeleteObjects stores specs for deleting a k8s fake object
+type DeleteObjects struct {
+	GVR       schema.GroupVersionResource
+	Kind      string
+	Namespace string
+	Name      string
+	Specs     runtime.Object
 }
 
 // CreateResource with fake client


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added skip delete event test case that should be skipped for resources which are not configured for delete event in test config.
Modified the resource configuration map AllowedEventKindsMap and removed delete event for pod.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

Fixes test case - Validate delete events are skipped when delete event is not configured for a resources in test config. e.g events: [create, update, error] of issue #354
