### PR TITLE
Reorder error check and defer file.close()

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,10 +228,11 @@ func NewCommunicationsConfig() (*Communications, error) {
 	configPath := os.Getenv("CONFIG_PATH")
 	communicationConfigFilePath := filepath.Join(configPath, CommunicationConfigFileName)
 	communicationConfigFile, err := os.Open(communicationConfigFilePath)
-	defer communicationConfigFile.Close()
+
 	if err != nil {
 		return c, err
 	}
+	defer communicationConfigFile.Close()
 
 	b, err := ioutil.ReadAll(communicationConfigFile)
 	if err != nil {
@@ -250,10 +251,11 @@ func New() (*Config, error) {
 	configPath := os.Getenv("CONFIG_PATH")
 	resourceConfigFilePath := filepath.Join(configPath, ResourceConfigFileName)
 	resourceConfigFile, err := os.Open(resourceConfigFilePath)
-	defer resourceConfigFile.Close()
+
 	if err != nil {
 		return c, err
 	}
+	defer resourceConfigFile.Close()
 
 	b, err := ioutil.ReadAll(resourceConfigFile)
 	if err != nil {


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Defering a file.close() should be done after the error returned by file.open() is checked, so I've reordered the statements.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->
