### PR TITLE
Add a support for ignoring the events from a namespace that matches regexp

### DIFF
--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -21,8 +21,8 @@ data:
         namespaces:               # List of namespaces, "all" will watch all the namespaces
           include:
             - all
-          ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all
-            -                     # example : include [all], ignore [x,y,z]
+          ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all, can contain a wildcard (*)
+            -                     # example : include [all], ignore [x,y,secret-ns-*]
         events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
           - create
           - delete

--- a/deploy-all-in-one.yaml
+++ b/deploy-all-in-one.yaml
@@ -21,8 +21,8 @@ data:
         namespaces:               # List of namespaces, "all" will watch all the namespaces
           include:
             - all
-          ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all
-            -                     # example : include [all], ignore [x,y,z]
+          ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all, can contain a wildcard (*)
+            -                     # example : include [all], ignore [x,y,secret-ns-*]
         events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
           - create
           - delete

--- a/helm/botkube/sample-res-config.yaml
+++ b/helm/botkube/sample-res-config.yaml
@@ -6,8 +6,8 @@ config:
       namespaces:               # List of namespaces, "all" will watch all the namespaces
         include:
           - all
-        ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all
-          - kube-system         # example : include [all], ignore [x,y,z]
+        ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all, can contain a wildcard (*)
+          - kube-system         # example : include [all], ignore [x,y,secret-ns-*]
       events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
         - create
         - delete

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -38,8 +38,8 @@ config:
       namespaces:               # List of namespaces, "all" will watch all the namespaces
         include:
           - all
-        ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all
-          -                     # example : include [all], ignore [x,y,z]
+        ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all, can contain a wildcard (*)
+          -                     # example : include [all], ignore [x,y,secret-ns-*]
       events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
         - create
         - delete

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,7 +121,8 @@ type UpdateSetting struct {
 //  - "all" to watch all the namespaces
 // Ignore contains a list of namespaces to be ignored when all namespaces are included
 // It is an optional (omitempty) field which is tandem with Include [all]
-// example : include [all], ignore [x,y,z]
+// It can also contain a * that would expand to zero or more arbitrary characters
+// example : include [all], ignore [x,y,secret-ns-*]
 type Namespaces struct {
 	Include []string
 	Ignore  []string `yaml:",omitempty"`

--- a/pkg/filterengine/filters/namespace_checker.go
+++ b/pkg/filterengine/filters/namespace_checker.go
@@ -86,7 +86,7 @@ func isNamespaceIgnored(resourceNamespaces config.Namespaces, eventNamespace str
 				if strings.Contains(ignoredNamespace, "*") {
 					ns := strings.Replace(ignoredNamespace, "*", ".*", -1)
 					matched, err := regexp.MatchString(ns, eventNamespace)
-					if matched && err == nil {
+					if err == nil && matched {
 						return true
 					}
 				}

--- a/pkg/filterengine/filters/namespace_checker.go
+++ b/pkg/filterengine/filters/namespace_checker.go
@@ -21,6 +21,7 @@ package filters
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/infracloudio/botkube/pkg/config"
@@ -75,9 +76,20 @@ func (f NamespaceChecker) Describe() string {
 func isNamespaceIgnored(resourceNamespaces config.Namespaces, eventNamespace string) bool {
 	if len(resourceNamespaces.Include) == 1 && resourceNamespaces.Include[0] == "all" {
 		if len(resourceNamespaces.Ignore) > 0 {
-			ignoredNamespaces := fmt.Sprintf("%#v", resourceNamespaces.Ignore)
-			if strings.Contains(ignoredNamespaces, eventNamespace) {
-				return true
+			for _, ignoredNamespace := range resourceNamespaces.Ignore {
+				// exact match
+				if ignoredNamespace == eventNamespace {
+					return true
+				}
+
+				// regexp
+				if strings.Contains(ignoredNamespace, "*") {
+					ns := strings.Replace(ignoredNamespace, "*", ".*", -1)
+					matched, err := regexp.MatchString(ns, eventNamespace)
+					if matched && err == nil {
+						return true
+					}
+				}
 			}
 		}
 	}

--- a/pkg/filterengine/filters/namespace_checker_test.go
+++ b/pkg/filterengine/filters/namespace_checker_test.go
@@ -31,9 +31,12 @@ func TestIsNamespaceIgnored(t *testing.T) {
 		eventNamespace string
 		expected       bool
 	}{
-		`include all and ignore few --> watch all except ignored`: {config.Namespaces{Include: []string{"all"}, Ignore: []string{"demo", "abc"}}, "demo", true},
-		`include all and ignore is "" --> watch all`:              {config.Namespaces{Include: []string{"all"}, Ignore: []string{""}}, "demo", false},
-		`include all and ignore is [] --> watch all`:              {config.Namespaces{Include: []string{"all"}, Ignore: []string{}}, "demo", false},
+		`include all and ignore few --> watch all except ignored`:                      {config.Namespaces{Include: []string{"all"}, Ignore: []string{"demo", "abc"}}, "demo", true},
+		`include all and ignore is "" --> watch all`:                                   {config.Namespaces{Include: []string{"all"}, Ignore: []string{""}}, "demo", false},
+		`include all and ignore is [] --> watch all`:                                   {config.Namespaces{Include: []string{"all"}, Ignore: []string{}}, "demo", false},
+		`include all and ignore with reqexp --> watch all except matched`:              {config.Namespaces{Include: []string{"all"}, Ignore: []string{"my-*"}}, "my-ns", true},
+		`include all and ignore few combined with regexp --> watch all except ignored`: {config.Namespaces{Include: []string{"all"}, Ignore: []string{"demo", "ignored-*-ns"}}, "ignored-42-ns", true},
+		`include all and ignore with regexp that doesn't match anything --> watch all`: {config.Namespaces{Include: []string{"all"}, Ignore: []string{"demo-*"}}, "demo", false},
 		// utils.AllowedEventKindsMap inherently handles remaining test case
 	}
 	for name, test := range tests {

--- a/resource_config.yaml
+++ b/resource_config.yaml
@@ -6,8 +6,8 @@ resources:
     namespaces:               # List of namespaces, "all" will watch all the namespaces
       include:  
         - all
-      ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all
-        -                     # example : include [all], ignore [x,y,z] 
+      ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all, can contain a wildcard (*)
+        -                     # example : include [all], ignore [x,y,secret-ns-*]
     events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
       - create
       - delete

--- a/test/resource_config.yaml
+++ b/test/resource_config.yaml
@@ -24,8 +24,8 @@ resources:
     namespaces:               # List of namespaces, "all" will watch all the namespaces
       include:
         - all
-      ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all
-        -                     # example : include [all], ignore [x,y,z] 
+      ignore:                 # List of namespaces to be ignored (omitempty), used only with include: all, can contain a wildcard (*)
+        -                     # example : include [all], ignore [x,y,secret-ns-*]
     events:                   # List of lifecycle events you want to receive, e.g create, update, delete, error OR all
       - create
       - delete


### PR DESCRIPTION
Fixes issue #295

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change allows to ignore whole sets of namespaces using the asterix expansion. It still does the exact match check for all the namespaces (separated by comma in config), but if it contains a `*`, it's actually replaced with `.*` and passed to `regexp.MatchString` to do the job.

PR also contains couple of very simple test cases.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->
deps:
`namespace_checker.go` now imports also `regexp`

Fixes #295

It's my very first golang code, so please let me know if it's not idiomatic go :cookie: 
