### PR TITLE
Added test case to validate delete event

### DIFF
--- a/test/e2e/notifier/delete/delete.go
+++ b/test/e2e/notifier/delete/delete.go
@@ -1,14 +1,17 @@
 package delete
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/notify"
 	"github.com/infracloudio/botkube/pkg/utils"
 	"github.com/infracloudio/botkube/test/e2e/env"
 	testutils "github.com/infracloudio/botkube/test/e2e/utils"
@@ -51,9 +54,81 @@ func (c *context) testSKipDeleteEvent(t *testing.T) {
 	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: "delete"}] = true
 }
 
+func (c *context) testDeleteEvent(t *testing.T) {
+	events := []config.EventType{"update", "error", "create"}
+
+	// Modifying AllowedEventKindsMap to remove events other than delete for pod resource
+	for _, event := range events {
+		delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: event})
+	}
+	// test scenarios
+	tests := map[string]testutils.DeleteObjects{
+		"perform delete operation with only delete event": {
+			GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Kind:      "Pod",
+			Namespace: "test",
+			Specs:     &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod-delete"}, Spec: v1.PodSpec{Containers: []v1.Container{{Name: "test-pod-container", Image: "tomcat:9.0.34"}}}},
+			ExpectedSlackMessage: testutils.SlackMessage{
+				Attachments: []slack.Attachment{{Color: "danger", Title: "v1/pods deleted", Fields: []slack.AttachmentField{{Value: "Pod *test/test-pod-delete* has been deleted in *test-cluster-1* cluster\n", Short: false}}, Footer: "BotKube"}},
+			},
+			ExpectedWebhookPayload: testutils.WebhookPayload{
+				EventMeta:   notify.EventMeta{Kind: "Pod", Name: "test-pod-delete", Namespace: "test", Cluster: "test-cluster-1"},
+				EventStatus: notify.EventStatus{Type: "delete", Level: "critical", Reason: "", Error: ""},
+				Summary:     "Pod *test/test-pod-delete* has been deleted in *test-cluster-1* cluster\n",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			resource := utils.GVRToString(test.GVR)
+			isAllowed := utils.AllowedEventKindsMap[utils.EventKind{
+				Resource:  resource,
+				Namespace: "all",
+				EventType: config.DeleteEvent}] ||
+				utils.AllowedEventKindsMap[utils.EventKind{
+					Resource:  resource,
+					Namespace: test.Namespace,
+					EventType: config.DeleteEvent}]
+			assert.Equal(t, isAllowed, true)
+
+			testutils.DeleteResource(t, test)
+
+			if c.TestEnv.Config.Communications.Slack.Enabled {
+
+				// Get last seen slack message
+				lastSeenMsg := c.GetLastSeenSlackMessage()
+
+				// Convert text message into Slack message structure
+				m := slack.Message{}
+				err := json.Unmarshal([]byte(*lastSeenMsg), &m)
+				if len(m.Attachments) != 0 {
+					m.Attachments[0].Ts = ""
+				}
+				assert.NoError(t, err, "message should decode properly")
+				assert.Equal(t, c.Config.Communications.Slack.Channel, m.Channel)
+				assert.Equal(t, test.ExpectedSlackMessage.Attachments, m.Attachments)
+			}
+
+			if c.TestEnv.Config.Communications.Webhook.Enabled {
+				// Get last seen webhook payload
+				lastSeenPayload := c.GetLastReceivedPayload()
+				assert.Equal(t, test.ExpectedWebhookPayload.EventMeta, lastSeenPayload.EventMeta)
+				assert.Equal(t, test.ExpectedWebhookPayload.EventStatus, lastSeenPayload.EventStatus)
+				assert.Equal(t, test.ExpectedWebhookPayload.Summary, lastSeenPayload.Summary)
+			}
+		})
+	}
+	// Resetting original configuration as per test_config
+	for _, event := range events {
+		utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: event}] = true
+	}
+}
+
 // Run tests
 func (c *context) Run(t *testing.T) {
-	t.Run("delete resource", c.testSKipDeleteEvent)
+	t.Run("skip delete event", c.testSKipDeleteEvent)
+	t.Run("delete resource", c.testDeleteEvent)
 }
 
 // E2ETests runs delete notification tests

--- a/test/e2e/notifier/delete/delete.go
+++ b/test/e2e/notifier/delete/delete.go
@@ -63,7 +63,7 @@ func (c *context) testDeleteEvent(t *testing.T) {
 	}
 	// test scenarios
 	tests := map[string]testutils.DeleteObjects{
-		"perform delete operation with only delete event": {
+		"perform delete operation and configure BotKube to listen only delete events": {
 			GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
 			Kind:      "Pod",
 			Namespace: "test",


### PR DESCRIPTION
Adds test case - Validate delete events are handled with only events: [delete] config for a resource.
Fixes part of #354 
