### PR TITLE
added test for skip delete event when resources are not added in test_config

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -160,14 +160,14 @@ func sendEvent(obj, oldObj interface{}, c *config.Config, notifiers []notify.Not
 	switch eventType {
 	case config.InfoEvent:
 		// Skip if ErrorEvent is not configured for the resource
-		if !utils.AllowedEventKindsMap[utils.EventKind{Resource: resource, Namespace: "all", EventType: config.ErrorEvent}] &&
-			!utils.AllowedEventKindsMap[utils.EventKind{Resource: resource, Namespace: objectMeta.Namespace, EventType: config.ErrorEvent}] {
+		if !utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.ErrorEvent) &&
+			!utils.CheckOperationAllowed(utils.AllowedEventKindsMap, objectMeta.Namespace, resource, config.ErrorEvent) {
 			log.Debugf("Ignoring %s to %s/%v in %s namespaces", eventType, resource, objectMeta.Name, objectMeta.Namespace)
 			return
 		}
 	default:
-		if !utils.AllowedEventKindsMap[utils.EventKind{Resource: resource, Namespace: "all", EventType: eventType}] &&
-			!utils.AllowedEventKindsMap[utils.EventKind{Resource: resource, Namespace: objectMeta.Namespace, EventType: eventType}] {
+		if !utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, eventType) &&
+			!utils.CheckOperationAllowed(utils.AllowedEventKindsMap, objectMeta.Namespace, resource, eventType) {
 			log.Debugf("Ignoring %s to %s/%v in %s namespaces", eventType, resource, objectMeta.Name, objectMeta.Namespace)
 			return
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -160,14 +160,12 @@ func sendEvent(obj, oldObj interface{}, c *config.Config, notifiers []notify.Not
 	switch eventType {
 	case config.InfoEvent:
 		// Skip if ErrorEvent is not configured for the resource
-		if !utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.ErrorEvent) &&
-			!utils.CheckOperationAllowed(utils.AllowedEventKindsMap, objectMeta.Namespace, resource, config.ErrorEvent) {
+		if !utils.CheckOperationAllowed(utils.AllowedEventKindsMap, objectMeta.Namespace, resource, config.ErrorEvent) {
 			log.Debugf("Ignoring %s to %s/%v in %s namespaces", eventType, resource, objectMeta.Name, objectMeta.Namespace)
 			return
 		}
 	default:
-		if !utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, eventType) &&
-			!utils.CheckOperationAllowed(utils.AllowedEventKindsMap, objectMeta.Namespace, resource, eventType) {
+		if !utils.CheckOperationAllowed(utils.AllowedEventKindsMap, objectMeta.Namespace, resource, eventType) {
 			log.Debugf("Ignoring %s to %s/%v in %s namespaces", eventType, resource, objectMeta.Name, objectMeta.Namespace)
 			return
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -372,3 +372,14 @@ func GetStringInYamlFormat(header string, commands map[string]bool) string {
 	}
 	return b.String()
 }
+
+// CheckOperationAllowed checks whether operation are allowed
+func CheckOperationAllowed(eventMap map[EventKind]bool, namespace string, resource string, eventType config.EventType) bool {
+	if eventMap[EventKind{
+		Resource:  resource,
+		Namespace: namespace,
+		EventType: eventType}] {
+		return true
+	}
+	return false
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -375,10 +375,14 @@ func GetStringInYamlFormat(header string, commands map[string]bool) string {
 
 // CheckOperationAllowed checks whether operation are allowed
 func CheckOperationAllowed(eventMap map[EventKind]bool, namespace string, resource string, eventType config.EventType) bool {
-	if eventMap != nil && eventMap[EventKind{
+	if eventMap != nil && (eventMap[EventKind{
 		Resource:  resource,
-		Namespace: namespace,
-		EventType: eventType}] {
+		Namespace: "all",
+		EventType: eventType}] ||
+		eventMap[EventKind{
+			Resource:  resource,
+			Namespace: namespace,
+			EventType: eventType}]) {
 		return true
 	}
 	return false

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -375,7 +375,7 @@ func GetStringInYamlFormat(header string, commands map[string]bool) string {
 
 // CheckOperationAllowed checks whether operation are allowed
 func CheckOperationAllowed(eventMap map[EventKind]bool, namespace string, resource string, eventType config.EventType) bool {
-	if eventMap[EventKind{
+	if eventMap != nil && eventMap[EventKind{
 		Resource:  resource,
 		Namespace: namespace,
 		EventType: eventType}] {

--- a/test/e2e/notifier/create/create.go
+++ b/test/e2e/notifier/create/create.go
@@ -129,7 +129,7 @@ func (c *context) testCreateResource(t *testing.T) {
 			}
 
 			resource := utils.GVRToString(test.GVR)
-			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.UpdateEvent)
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.CreateEvent)
 			assert.Equal(t, isAllowed, true)
 		})
 	}

--- a/test/e2e/notifier/create/create.go
+++ b/test/e2e/notifier/create/create.go
@@ -129,14 +129,7 @@ func (c *context) testCreateResource(t *testing.T) {
 			}
 
 			resource := utils.GVRToString(test.GVR)
-			isAllowed := utils.AllowedEventKindsMap[utils.EventKind{
-				Resource:  resource,
-				Namespace: "all",
-				EventType: config.CreateEvent}] ||
-				utils.AllowedEventKindsMap[utils.EventKind{
-					Resource:  resource,
-					Namespace: test.Namespace,
-					EventType: config.CreateEvent}]
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.CreateEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.CreateEvent)
 			assert.Equal(t, isAllowed, true)
 		})
 	}

--- a/test/e2e/notifier/create/create.go
+++ b/test/e2e/notifier/create/create.go
@@ -129,7 +129,7 @@ func (c *context) testCreateResource(t *testing.T) {
 			}
 
 			resource := utils.GVRToString(test.GVR)
-			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.CreateEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.CreateEvent)
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.UpdateEvent)
 			assert.Equal(t, isAllowed, true)
 		})
 	}

--- a/test/e2e/notifier/delete/delete.go
+++ b/test/e2e/notifier/delete/delete.go
@@ -60,7 +60,7 @@ func (c *context) testSKipDeleteEvent(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resource := utils.GVRToString(test.GVR)
 			// checking if delete operation is skipped
-			isAllowed := testutils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.DeleteEvent)
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.DeleteEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.DeleteEvent)
 			assert.Equal(t, isAllowed, false)
 		})
 	}
@@ -101,7 +101,7 @@ func (c *context) testDeleteEvent(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			resource := utils.GVRToString(test.GVR)
-			isAllowed := testutils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.DeleteEvent)
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.DeleteEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.DeleteEvent)
 			assert.Equal(t, isAllowed, true)
 
 			testutils.DeleteResource(t, test)

--- a/test/e2e/notifier/delete/delete.go
+++ b/test/e2e/notifier/delete/delete.go
@@ -26,6 +26,10 @@ func (c *context) testSKipDeleteEvent(t *testing.T) {
 	delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: "delete"})
 	// Modifying AllowedEventKindsMap to add delete event for only dummy namespace and ignore everything
 	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/pods", Namespace: "dummy", EventType: "delete"}] = true
+	// Modifying AllowedEventKindsMap to remove all event for service resource
+	delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/services", Namespace: "all", EventType: "delete"})
+	delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/services", Namespace: "all", EventType: "create"})
+	delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/services", Namespace: "all", EventType: "error"})
 	// test scenarios
 	tests := map[string]testutils.DeleteObjects{
 		"skip delete event for resources not configured": {
@@ -41,6 +45,13 @@ func (c *context) testSKipDeleteEvent(t *testing.T) {
 			Kind:      "Pod",
 			Namespace: "test",
 			Specs:     &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod-delete"}, Spec: v1.PodSpec{Containers: []v1.Container{{Name: "test-pod-container", Image: "tomcat:9.0.34"}}}},
+		},
+		"skip delete event for resources not added in test_config": {
+			// delete operation not allowed for Pod resources so event should be skipped
+			GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"},
+			Kind:      "Service",
+			Namespace: "test",
+			Specs:     &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-service-delete"}},
 		},
 	}
 
@@ -62,6 +73,10 @@ func (c *context) testSKipDeleteEvent(t *testing.T) {
 	// Resetting original configuration as per test_config
 	defer delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/pods", Namespace: "dummy", EventType: "delete"})
 	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: "delete"}] = true
+	// Resetting original configuration as per test_config adding service resource
+	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/services", Namespace: "all", EventType: "delete"}] = true
+	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/services", Namespace: "all", EventType: "error"}] = true
+	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/services", Namespace: "all", EventType: "create"}] = true
 }
 
 func (c *context) testDeleteEvent(t *testing.T) {

--- a/test/e2e/notifier/delete/delete.go
+++ b/test/e2e/notifier/delete/delete.go
@@ -60,7 +60,7 @@ func (c *context) testSKipDeleteEvent(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resource := utils.GVRToString(test.GVR)
 			// checking if delete operation is skipped
-			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.DeleteEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.DeleteEvent)
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.DeleteEvent)
 			assert.Equal(t, isAllowed, false)
 		})
 	}
@@ -101,7 +101,7 @@ func (c *context) testDeleteEvent(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			resource := utils.GVRToString(test.GVR)
-			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.DeleteEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.DeleteEvent)
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.DeleteEvent)
 			assert.Equal(t, isAllowed, true)
 
 			testutils.DeleteResource(t, test)

--- a/test/e2e/notifier/update/update.go
+++ b/test/e2e/notifier/update/update.go
@@ -182,14 +182,7 @@ func (c *context) testSKipUpdateEvent(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resource := utils.GVRToString(test.GVR)
 			// checking if update operation is true
-			isAllowed := utils.AllowedEventKindsMap[utils.EventKind{
-				Resource:  resource,
-				Namespace: "all",
-				EventType: config.UpdateEvent}] ||
-				utils.AllowedEventKindsMap[utils.EventKind{
-					Resource:  resource,
-					Namespace: test.Namespace,
-					EventType: config.UpdateEvent}]
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.UpdateEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.UpdateEvent)
 			assert.Equal(t, isAllowed, false)
 		})
 	}
@@ -234,14 +227,7 @@ func (c *context) testSkipWrongSetting(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resource := utils.GVRToString(test.GVR)
 			// checking if update operation is true
-			isAllowed := utils.AllowedEventKindsMap[utils.EventKind{
-				Resource:  resource,
-				Namespace: "all",
-				EventType: config.UpdateEvent}] ||
-				utils.AllowedEventKindsMap[utils.EventKind{
-					Resource:  resource,
-					Namespace: test.Namespace,
-					EventType: config.UpdateEvent}]
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.UpdateEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.UpdateEvent)
 			assert.Equal(t, isAllowed, true)
 			// modifying the update setting value as per testcases
 			utils.AllowedUpdateEventsMap[utils.KindNS{Resource: "v1/pods", Namespace: "all"}] = test.UpdateSetting

--- a/test/e2e/notifier/update/update.go
+++ b/test/e2e/notifier/update/update.go
@@ -182,7 +182,7 @@ func (c *context) testSKipUpdateEvent(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resource := utils.GVRToString(test.GVR)
 			// checking if update operation is true
-			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.UpdateEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.UpdateEvent)
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.UpdateEvent)
 			assert.Equal(t, isAllowed, false)
 		})
 	}
@@ -227,7 +227,7 @@ func (c *context) testSkipWrongSetting(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resource := utils.GVRToString(test.GVR)
 			// checking if update operation is true
-			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, "all", resource, config.UpdateEvent) || utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.UpdateEvent)
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.UpdateEvent)
 			assert.Equal(t, isAllowed, true)
 			// modifying the update setting value as per testcases
 			utils.AllowedUpdateEventsMap[utils.KindNS{Resource: "v1/pods", Namespace: "all"}] = test.UpdateSetting

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -149,17 +149,3 @@ func DeleteResource(t *testing.T, obj DeleteObjects) {
 		t.Fatalf("Failed to delete %s: %v", obj.GVR.Resource, err)
 	}
 }
-
-// CheckOperationAllowed checks whether operation are allowed
-func CheckOperationAllowed(eventMap map[utils.EventKind]bool, namespace string, resource string, eventType config.EventType) bool {
-	if eventMap[utils.EventKind{
-		Resource:  resource,
-		Namespace: "all",
-		EventType: eventType}] || eventMap[utils.EventKind{
-		Resource:  resource,
-		Namespace: namespace,
-		EventType: eventType}] {
-		return true
-	}
-	return false
-}

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -162,5 +162,4 @@ func CheckOperationAllowed(eventMap map[utils.EventKind]bool, namespace string, 
 		return true
 	}
 	return false
-
 }

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -149,3 +149,18 @@ func DeleteResource(t *testing.T, obj DeleteObjects) {
 		t.Fatalf("Failed to delete %s: %v", obj.GVR.Resource, err)
 	}
 }
+
+// CheckOperationAllowed checks whether operation are allowed
+func CheckOperationAllowed(eventMap map[utils.EventKind]bool, namespace string, resource string, eventType config.EventType) bool {
+	if eventMap[utils.EventKind{
+		Resource:  resource,
+		Namespace: "all",
+		EventType: eventType}] || eventMap[utils.EventKind{
+		Resource:  resource,
+		Namespace: namespace,
+		EventType: eventType}] {
+		return true
+	}
+	return false
+
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->
Added skip delete event test case that should be skipped if event occurred for a resource which is not added in test configuration.
Modified AllowedEventKindsMap to removed the v1/services resource
<!--- Please list dependencies added with your change also -->

Fixes test case - Validate that delete events are skipped when an event occurs for a resource which is not added in resource_config of issue #354
