### PR TITLE
Added test case to validate error event

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/infracloudio/botkube/test/e2e/filters"
 	"github.com/infracloudio/botkube/test/e2e/notifier/create"
 	"github.com/infracloudio/botkube/test/e2e/notifier/delete"
+	"github.com/infracloudio/botkube/test/e2e/notifier/error"
 	"github.com/infracloudio/botkube/test/e2e/notifier/update"
 	"github.com/infracloudio/botkube/test/e2e/welcome"
 )
@@ -88,6 +89,7 @@ func TestRun(t *testing.T) {
 		"filters":  filters.E2ETests(testEnv),
 		"update":   update.E2ETests(testEnv),
 		"delete":   delete.E2ETests(testEnv),
+		"error":    error.E2ETests(testEnv),
 	}
 
 	// Run test suite

--- a/test/e2e/notifier/error/error.go
+++ b/test/e2e/notifier/error/error.go
@@ -1,0 +1,68 @@
+package error
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/utils"
+	"github.com/infracloudio/botkube/test/e2e/env"
+	testutils "github.com/infracloudio/botkube/test/e2e/utils"
+)
+
+type context struct {
+	*env.TestEnv
+}
+
+func (c *context) testSKipErrorEvent(t *testing.T) {
+	// Modifying AllowedEventKindsMap to remove error event for pod resource
+	delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: "error"})
+
+	// Modifying AllowedEventKindsMap to add error event for only dummy namespace and ignore everything
+	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/pods", Namespace: "dummy", EventType: "error"}] = true
+
+	tests := map[string]testutils.ErrorEvent{
+		"skip error event for resources not configured": {
+			// error event not allowed for Pod resources so event should be skipped
+			GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Kind:      "Pod",
+			Namespace: "test",
+			Specs:     &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}, Spec: v1.PodSpec{Containers: []v1.Container{{Name: "test-pod-container", Image: "tomcat:9.0.34"}}}},
+		},
+		"skip error event for namespace not configured": {
+			// error event not allowed for Pod in test namespace so event should be skipped
+			GVR:       schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			Kind:      "Pod",
+			Namespace: "test",
+			Specs:     &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}, Spec: v1.PodSpec{Containers: []v1.Container{{Name: "test-pod-container", Image: "tomcat:9.0.34"}}}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			resource := utils.GVRToString(test.GVR)
+			// checking if error operation is skipped
+			isAllowed := utils.CheckOperationAllowed(utils.AllowedEventKindsMap, test.Namespace, resource, config.ErrorEvent)
+			assert.Equal(t, isAllowed, false)
+		})
+	}
+	// Resetting original configuration as per test_config
+	defer delete(utils.AllowedEventKindsMap, utils.EventKind{Resource: "v1/pods", Namespace: "dummy", EventType: "error"})
+	utils.AllowedEventKindsMap[utils.EventKind{Resource: "v1/pods", Namespace: "all", EventType: "error"}] = true
+}
+
+// Run tests
+func (c *context) Run(t *testing.T) {
+	t.Run("skip error event", c.testSKipErrorEvent)
+}
+
+// E2ETests runs error notification tests
+func E2ETests(testEnv *env.TestEnv) env.E2ETest {
+	return &context{
+		testEnv,
+	}
+}

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -85,6 +85,17 @@ type DeleteObjects struct {
 	ExpectedSlackMessage   SlackMessage
 }
 
+// ErrorEvent stores specs for throwing an error in case of anomalies
+type ErrorEvent struct {
+	GVR                    schema.GroupVersionResource
+	Kind                   string
+	Namespace              string
+	Name                   string
+	Specs                  runtime.Object
+	ExpectedWebhookPayload WebhookPayload
+	ExpectedSlackMessage   SlackMessage
+}
+
 // CreateResource with fake client
 func CreateResource(t *testing.T, obj CreateObjects) {
 	// convert the runtime.Object to unstructured.Unstructured


### PR DESCRIPTION
- Validates error events are skipped when the error event is not configured for a resource in test config.
- Validate that error events are skipped when an event occurs for a namespace which is not added in resource_config
Fixes part of #340 
