### PR TITLE
feat(slack): add thread support

### DIFF
--- a/hack/runtests.sh
+++ b/hack/runtests.sh
@@ -20,7 +20,7 @@
 
 
 set -o errexit
-#set -o nounset
+
 set -o pipefail
 
 export CONFIG_PATH="$(pwd)/test"

--- a/hack/runtests.sh
+++ b/hack/runtests.sh
@@ -20,7 +20,7 @@
 
 
 set -o errexit
-set -o nounset
+#set -o nounset
 set -o pipefail
 
 export CONFIG_PATH="$(pwd)/test"

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -180,7 +180,14 @@ func (sm *slackMessage) Send() {
 		return
 	}
 
-	if _, _, err := sm.RTM.PostMessage(sm.Event.Channel, slack.MsgOptionText("```"+sm.Response+"```", false), slack.MsgOptionAsUser(true)); err != nil {
+	var options = []slack.MsgOption {slack.MsgOptionText("```"+sm.Response+"```", false), slack.MsgOptionAsUser(true)}
+	
+	//if the message is from thread then add an option to return the response to the thread
+	if (sm.Event.ThreadTimestamp != ""){
+		options = append(options,  slack.MsgOptionTS(sm.Event.ThreadTimestamp))
+	}
+
+	if _, _, err := sm.RTM.PostMessage(sm.Event.Channel, options...); err != nil {
 		log.Error("Error in sending message:", err)
 	}
 }

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -180,11 +180,11 @@ func (sm *slackMessage) Send() {
 		return
 	}
 
-	var options = []slack.MsgOption {slack.MsgOptionText("```"+sm.Response+"```", false), slack.MsgOptionAsUser(true)}
-	
+	var options = []slack.MsgOption{slack.MsgOptionText("```"+sm.Response+"```", false), slack.MsgOptionAsUser(true)}
+
 	//if the message is from thread then add an option to return the response to the thread
-	if (sm.Event.ThreadTimestamp != ""){
-		options = append(options,  slack.MsgOptionTS(sm.Event.ThreadTimestamp))
+	if sm.Event.ThreadTimestamp != "" {
+		options = append(options, slack.MsgOptionTS(sm.Event.ThreadTimestamp))
 	}
 
 	if _, _, err := sm.RTM.PostMessage(sm.Event.Channel, options...); err != nil {


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
adding support for botkube to interact in slack threads
I did update the test bash script that would not run on my zsh shell on my mac.

I Also wanted to add some unit tests but the Slack test server does not support thread messages.

Fixes #422
