### PR TITLE
Fixed namespace checker to use the correct name

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -51,6 +51,7 @@ type Event struct {
 	Count     int32
 	Action    string
 	Skip      bool `json:",omitempty"`
+	Resource  string
 
 	Recommendations []string
 	Warnings        []string
@@ -121,7 +122,8 @@ func New(object interface{}, eventType config.EventType, resource, clusterName s
 		event.Count = eventObj.Count
 		event.Action = eventObj.Action
 		event.TimeStamp = eventObj.LastTimestamp.Time
-
+		tempResourceName, _ := utils.GetResourceFromKind(eventObj.InvolvedObject.GroupVersionKind())
+		event.Resource = utils.GVRToString(tempResourceName)
 	}
 	return event
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -122,8 +122,7 @@ func New(object interface{}, eventType config.EventType, resource, clusterName s
 		event.Count = eventObj.Count
 		event.Action = eventObj.Action
 		event.TimeStamp = eventObj.LastTimestamp.Time
-		tempResourceName, _ := utils.GetResourceFromKind(eventObj.InvolvedObject.GroupVersionKind())
-		event.Resource = utils.GVRToString(tempResourceName)
+		event.Resource = resource
 	}
 	return event
 }

--- a/pkg/filterengine/filters/namespace_checker.go
+++ b/pkg/filterengine/filters/namespace_checker.go
@@ -56,8 +56,7 @@ func (f NamespaceChecker) Run(object interface{}, event *events.Event) {
 	}
 	if botkubeConfig != nil {
 		for _, resource := range botkubeConfig.Resources {
-			resourceName := strings.Split(strings.ToLower(event.Title), " ")[0]
-			if resource.Name == resourceName {
+			if resource.Name == event.Resource {
 				// check if namespace to be ignored
 				if isNamespaceIgnored(resource.Namespaces, event.Namespace) {
 					event.Skip = true

--- a/pkg/filterengine/filters/namespace_checker.go
+++ b/pkg/filterengine/filters/namespace_checker.go
@@ -56,7 +56,8 @@ func (f NamespaceChecker) Run(object interface{}, event *events.Event) {
 	}
 	if botkubeConfig != nil {
 		for _, resource := range botkubeConfig.Resources {
-			if resource.Name == strings.ToLower(event.Kind) {
+			resourceName := strings.Split(strings.ToLower(event.Title), " ")[0]
+			if resource.Name == resourceName {
 				// check if namespace to be ignored
 				if isNamespaceIgnored(resource.Namespaces, event.Namespace) {
 					event.Skip = true


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY
Apparently the wrong member was used to check the resource name. I don't
know how resillient this patch is, but it works for most of the part.

<!--- Please list dependencies added with your change also -->

Fixes #419
