### PR TITLE
Cluster name for commands

### DIFF
--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -80,6 +80,8 @@ const (
 	NotifierStartMsg = "Brace yourselves, notifications are coming from cluster '%s'."
 	// IncompleteCmdMsg incomplete command response message
 	IncompleteCmdMsg = "You missed to pass options for the command. Please run /botkubehelp to see command options."
+	// WrongClusterCmdMsg incomplete command response message
+	WrongClusterCmdMsg = "Sorry, the admin hasn't configured me to do that for the cluster '%s'."
 
 	// Custom messages for teams platform
 	teamsUnsupportedCmdMsg = "Command not supported. Please visit botkube.io/usage to see supported commands."
@@ -386,6 +388,11 @@ func (e *DefaultExecutor) runInfoCommand(args []string, isAuthChannel bool) stri
 	if len(args) < 2 && args[1] != string(infoList) {
 		return IncompleteCmdMsg
 	}
+
+	if len(args) > 3 && args[2] == ClusterFlag.String() && args[3] != e.ClusterName {
+		return fmt.Sprintf(WrongClusterCmdMsg, args[3])
+	}
+
 	return makeCommandInfoList()
 }
 

--- a/test/e2e/command/botkube.go
+++ b/test/e2e/command/botkube.go
@@ -83,6 +83,32 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 				"  - statefulsets\n" +
 				"  - storageclasses\n",
 		},
+		"BotKube commands list with cluster name": {
+			command: "commands list --cluster-name test-cluster-1",
+			expected: "allowed verbs:\n" +
+				"  - api-resources\n" +
+				"  - describe\n" +
+				"  - diff\n" +
+				"  - explain\n" +
+				"  - get\n" +
+				"  - logs\n" +
+				"  - api-versions\n" +
+				"  - cluster-info\n" +
+				"  - top\n" +
+				"  - auth\n" +
+				"allowed resources:\n" +
+				"  - nodes\n" +
+				"  - deployments\n" +
+				"  - pods\n" +
+				"  - namespaces\n" +
+				"  - daemonsets\n" +
+				"  - statefulsets\n" +
+				"  - storageclasses\n",
+		},
+		"BotKube command list with wrong cluster name": {
+			command:  "commands list --cluster-name test-cluster-2",
+			expected: "Sorry, the admin hasn't configured me to do that for the cluster 'test-cluster-2'.",
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -103,6 +129,10 @@ func (c *context) testBotkubeCommand(t *testing.T) {
 				case "filters list":
 					fl := compareFilters(strings.Split(test.expected, "\n"), strings.Split(strings.Trim(m.Text, "```"), "\n"))
 					assert.Equal(t, fl, true)
+				case "commands list --cluster-name test-cluster-2":
+					fallthrough
+				case "commands list --cluster-name test-cluster-1":
+					fallthrough
 				case "commands list":
 					cl := compareFilters(strings.Split(test.expected, "\n"), strings.Split(strings.Trim(m.Text, "```"), "\n"))
 					assert.Equal(t, cl, true)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY
Checks for the cluster name for the `commands list` command if passed.

Fixes #420 

![2020-12-10-115425_1920x1080_scrot](https://user-images.githubusercontent.com/12135951/101729661-97de2180-3ade-11eb-986b-123398a89a2e.png)

