### PR TITLE
Fix notification timestsamp in Discord

### DIFF
--- a/pkg/notify/discord.go
+++ b/pkg/notify/discord.go
@@ -29,7 +29,7 @@ import (
 )
 
 // customTimeFormat holds custom time format string
-const customTimeFormat = "2006-01-02 15:04:05"
+const customTimeFormat = "2006-01-02T15:04:05Z"
 
 var embedColor = map[config.Level]int{
 	config.Info:     8311585,  // green
@@ -110,7 +110,7 @@ func formatDiscordMessage(event events.Event, notifyType config.NotifType) disco
 	}
 
 	// Add timestamp
-	messageEmbed.Timestamp = event.TimeStamp.Format(customTimeFormat)
+	messageEmbed.Timestamp = event.TimeStamp.UTC().Format(customTimeFormat)
 
 	messageEmbed.Color = embedColor[event.Level]
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY

Use correct timestamp in Discord event notification 

Fixes #441 

##### Test plan

![image](https://user-images.githubusercontent.com/7098659/103475090-43be1880-4dd0-11eb-9a5c-2406d2d4f954.png)

