### PR TITLE
Use uniform response format

### DIFF
--- a/pkg/bot/discord.go
+++ b/pkg/bot/discord.go
@@ -96,7 +96,6 @@ func (b *DiscordBot) Start() {
 
 // HandleMessage handles the incoming messages
 func (dm *discordMessage) HandleMessage(b *DiscordBot) {
-
 	// Serve only if starts with mention
 	if !strings.HasPrefix(dm.Event.Content, "<@!"+dm.BotID+"> ") && !strings.HasPrefix(dm.Event.Content, "<@"+dm.BotID+"> ") {
 		return
@@ -129,6 +128,11 @@ func (dm discordMessage) Send() {
 	log.Debugf("Discord incoming Request: %s", dm.Request)
 	log.Debugf("Discord Response: %s", dm.Response)
 
+	if len(dm.Response) == 0 {
+		log.Infof("Invalid request. Dumping the response. Request: %s", dm.Request)
+		return
+	}
+
 	// Upload message as a file if too long
 	if len(dm.Response) >= 2000 {
 		params := &discordgo.MessageSend{
@@ -140,17 +144,13 @@ func (dm discordMessage) Send() {
 				},
 			},
 		}
-
 		if _, err := dm.Session.ChannelMessageSendComplex(dm.Event.ChannelID, params); err != nil {
 			log.Error("Error in uploading file:", err)
 		}
 		return
-	} else if len(dm.Response) == 0 {
-		log.Info("Invalid request. Dumping the response")
-		return
 	}
 
-	if _, err := dm.Session.ChannelMessageSend(dm.Event.ChannelID, dm.Response); err != nil {
+	if _, err := dm.Session.ChannelMessageSend(dm.Event.ChannelID, formatCodeBlock(dm.Response)); err != nil {
 		log.Error("Error in sending message:", err)
 	}
 }

--- a/pkg/bot/slack.go
+++ b/pkg/bot/slack.go
@@ -159,6 +159,10 @@ func (sm *slackMessage) HandleMessage(b *SlackBot) {
 func (sm *slackMessage) Send() {
 	log.Debugf("Slack incoming Request: %s", sm.Request)
 	log.Debugf("Slack Response: %s", sm.Response)
+	if len(sm.Response) == 0 {
+		log.Infof("Invalid request. Dumping the response. Request: %s", sm.Request)
+		return
+	}
 	// Upload message as a file if too long
 	if len(sm.Response) >= 3990 {
 		params := slack.FileUploadParameters{
@@ -172,12 +176,9 @@ func (sm *slackMessage) Send() {
 			log.Error("Error in uploading file:", err)
 		}
 		return
-	} else if len(sm.Response) == 0 {
-		log.Info("Invalid request. Dumping the response")
-		return
 	}
 
-	var options = []slack.MsgOption{slack.MsgOptionText("```"+sm.Response+"```", false), slack.MsgOptionAsUser(true)}
+	var options = []slack.MsgOption{slack.MsgOptionText(formatCodeBlock(sm.Response), false), slack.MsgOptionAsUser(true)}
 
 	//if the message is from thread then add an option to return the response to the thread
 	if sm.Event.ThreadTimestamp != "" {

--- a/pkg/bot/teams.go
+++ b/pkg/bot/teams.go
@@ -259,7 +259,7 @@ func (t *Teams) processMessage(activity schema.Activity) string {
 	// Multicluster is not supported for Teams
 	e := execute.NewDefaultExecutor(msg, t.AllowKubectl, t.RestrictAccess, t.DefaultNamespace,
 		t.ClusterName, config.TeamsBot, "", true)
-	return fmt.Sprintf("```\n%s\n```", e.Execute())
+	return formatCodeBlock(e.Execute())
 }
 
 func (t *Teams) putRequest(u string, data []byte) error {

--- a/pkg/bot/utils.go
+++ b/pkg/bot/utils.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 InfraCloud Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package bot
+
+import (
+	"fmt"
+)
+
+func formatCodeBlock(msg string) string {
+	return fmt.Sprintf("```%s```", msg)
+}


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Use uniform `codeblock` format for command responses across different integrations 

![image](https://user-images.githubusercontent.com/7098659/105995940-ac4a9d80-60cf-11eb-9f7f-962bcc626968.png)
