### PR TITLE
Add affinity to helm deployment

### DIFF
--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}


### PR DESCRIPTION
##### ISSUE TYPE

 - Bug fix Pull Request

##### SUMMARY

I use `affinity` to schedule pods, I saw it's mentioned in a chart and was surprised why it was not used. `nodeSelector` & `tolerations` present, but `affinity` was missing from the template.