### PR TITLE
corrected defaultNamespace population and avoid appending defaultnamespace if already passed 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,8 +213,8 @@ type Webhook struct {
 type Kubectl struct {
 	Enabled          bool
 	Commands         Commands
-	DefaultNamespace string
-	RestrictAccess   bool `yaml:"restrictAccess"`
+	DefaultNamespace string `yaml:"defaultNamespace"`
+	RestrictAccess   bool   `yaml:"restrictAccess"`
 }
 
 // Commands allowed in bot

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -256,10 +256,8 @@ func trimQuotes(clusterValue string) string {
 func runKubectlCommand(args []string, clusterName, defaultNamespace string, isAuthChannel bool) string {
 
 	// run commands in namespace specified under Config.Settings.DefaultNamespace field
-	if len(defaultNamespace) != 0 {
+	if !utils.Contains(args, "-n") && len(defaultNamespace) != 0 {
 		args = append([]string{"-n", defaultNamespace}, utils.DeleteDoubleWhiteSpace(args)...)
-	} else {
-		args = append([]string{"-n", "default"}, utils.DeleteDoubleWhiteSpace(args)...)
 	}
 
 	// Remove unnecessary flags

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -256,7 +256,7 @@ func trimQuotes(clusterValue string) string {
 func runKubectlCommand(args []string, clusterName, defaultNamespace string, isAuthChannel bool) string {
 
 	// run commands in namespace specified under Config.Settings.DefaultNamespace field
-	if !utils.Contains(args, "-n") && len(defaultNamespace) != 0 {
+	if !utils.Contains(args, "-n") && !utils.Contains(args, "--namespace") && len(defaultNamespace) != 0 {
 		args = append([]string{"-n", defaultNamespace}, utils.DeleteDoubleWhiteSpace(args)...)
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -387,3 +387,13 @@ func CheckOperationAllowed(eventMap map[EventKind]bool, namespace string, resour
 	}
 	return false
 }
+
+// Contains tells whether a contains x.
+func Contains(a []string, x string) bool {
+	for _, n := range a {
+		if strings.ToLower(x) == strings.ToLower(n) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -62,3 +62,24 @@ func TestGetStringInYamlFormat(t *testing.T) {
 		t.Errorf("expected: %v, got: %v", expected, got)
 	}
 }
+
+func TestContains(t *testing.T) {
+	var containsValue = "default"
+	var notContainsValue = "demo"
+	var commands = []string{
+		"get",
+		"pods",
+		"-n",
+		"default",
+	}
+	expected := true
+	got := Contains(commands, containsValue)
+	if got != expected {
+		t.Errorf("expected: %v, got: %v", expected, got)
+	}
+	expected = false
+	got = Contains(commands, notContainsValue)
+	if got != expected {
+		t.Errorf("expected: %v, got: %v", expected, got)
+	}
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Resolved issue of DefaultNamespace value is not getting populated in config and appending default namespace if another namespace is already passed
