### PR TITLE
remove unwanted hyperlink text from command

### DIFF
--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -181,7 +181,9 @@ func NewDefaultExecutor(msg string, allowkubectl, restrictAccess bool, defaultNa
 
 // Execute executes commands and returns output
 func (e *DefaultExecutor) Execute() string {
-	args := strings.Fields(strings.TrimSpace(e.Message))
+	//Remove hyperlink if it got added automatically
+	command := utils.RemoveHyperlink(e.Message)
+	args := strings.Fields(strings.TrimSpace(command))
 	if len(args) == 0 {
 		if e.IsAuthChannel {
 			return printDefaultMsg(e.Platform)
@@ -278,12 +280,6 @@ func runKubectlCommand(args []string, clusterName, defaultNamespace string, isAu
 		if strings.HasPrefix(arg, ClusterFlag.String()) {
 			// Check if flag value in current or next argument and compare with config.settings.clustername
 			if arg == ClusterFlag.String() {
-				nextArgasClusterName := args[index+1]
-				//This will remove 'http://' from clustername if it is automatically added
-				if strings.Contains(nextArgasClusterName, "<http://") {
-					nerCommands := strings.Split(nextArgasClusterName, "|")
-					args[index+1] = strings.Replace(nerCommands[1], ">", "", 1)
-				}
 				if index == len(args)-1 || trimQuotes(args[index+1]) != clusterName {
 					return ""
 				}

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -181,7 +181,7 @@ func NewDefaultExecutor(msg string, allowkubectl, restrictAccess bool, defaultNa
 
 // Execute executes commands and returns output
 func (e *DefaultExecutor) Execute() string {
-	//Remove hyperlink if it got added automatically
+	// Remove hyperlink if it got added automatically
 	command := utils.RemoveHyperlink(e.Message)
 	args := strings.Fields(strings.TrimSpace(command))
 	if len(args) == 0 {

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -278,6 +278,12 @@ func runKubectlCommand(args []string, clusterName, defaultNamespace string, isAu
 		if strings.HasPrefix(arg, ClusterFlag.String()) {
 			// Check if flag value in current or next argument and compare with config.settings.clustername
 			if arg == ClusterFlag.String() {
+				nextArgasClusterName := args[index+1]
+				//This will remove 'http://' from clustername if it is automatically added
+				if strings.Contains(nextArgasClusterName, "<http://") {
+					nerCommands := strings.Split(nextArgasClusterName, "|")
+					args[index+1] = strings.Replace(nerCommands[1], ">", "", 1)
+				}
 				if index == len(args)-1 || trimQuotes(args[index+1]) != clusterName {
 					return ""
 				}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -73,6 +73,8 @@ var (
 	DiscoveryClient discovery.DiscoveryInterface
 )
 
+const hyperlinkRegex = `(?m)<http:\/\/[a-z.0-9\/\-_=]*\|([a-z.0-9\/\-_=]*)>`
+
 // InitKubeClient creates K8s client from provided kubeconfig OR service account to interact with apiserver
 func InitKubeClient() {
 	kubeConfig, err := rest.InClusterConfig()
@@ -398,11 +400,11 @@ func Contains(a []string, x string) bool {
 	return false
 }
 
-//RemoveHyperlink removes the hyperlink text from url
+// RemoveHyperlink removes the hyperlink text from url
 func RemoveHyperlink(hyperlink string) string {
-	var command = hyperlink
-	var hyperlinkRegex = regexp.MustCompile(`(?m)<http:\/\/[a-z.0-9\/\-_=]*\|([a-z.0-9\/\-_=]*)>`)
-	matched := hyperlinkRegex.FindAllStringSubmatch(string(hyperlink), -1)
+	command := hyperlink
+	compiledRegex := regexp.MustCompile(hyperlinkRegex)
+	matched := compiledRegex.FindAllStringSubmatch(string(hyperlink), -1)
 	if len(matched) >= 1 {
 		for _, match := range matched {
 			if len(match) == 2 {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -397,3 +397,18 @@ func Contains(a []string, x string) bool {
 	}
 	return false
 }
+
+//RemoveHyperlink removes the hyperlink text from url
+func RemoveHyperlink(hyperlink string) string {
+	var command = hyperlink
+	var hyperlinkRegex = regexp.MustCompile(`(?m)<http:\/\/[a-z.0-9\/\-_=]*\|([a-z.0-9\/\-_=]*)>`)
+	matched := hyperlinkRegex.FindAllStringSubmatch(string(hyperlink), -1)
+	if len(matched) >= 1 {
+		for _, match := range matched {
+			if len(match) == 2 {
+				command = strings.ReplaceAll(command, match[0], match[1])
+			}
+		}
+	}
+	return command
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -92,10 +92,16 @@ func TestRemoveHypelink(t *testing.T) {
 	}
 
 	tests := []test{
-		{input: "get <http://prometheuses.monitoring.coreos.com|prometheuses.monitoring.coreos.com> --cluster-name <http://xyz.alpha-sense.org|xyz.alpha-sense.org>", expected: "get prometheuses.monitoring.coreos.com --cluster-name xyz.alpha-sense.org"},
-		{input: "get <http://prometheuses.monitoring.coreos.com|prometheuses.monitoring.coreos.com>", expected: "get prometheuses.monitoring.coreos.com"},
-		{input: "get pods --cluster-name <http://xyz.alpha-sense.org|xyz.alpha-sense.org>", expected: "get pods --cluster-name xyz.alpha-sense.org"},
-		{input: "get pods -n=default", expected: "get pods -n=default"},
+		{input: "get <http://prometheuses.monitoring.coreos.com|prometheuses.monitoring.coreos.com> --cluster-name <http://xyz.alpha-sense.org|xyz.alpha-sense.org>",
+			expected: "get prometheuses.monitoring.coreos.com --cluster-name xyz.alpha-sense.org"},
+		{input: "get <http://prometheuses.monitoring.coreos.com|prometheuses.monitoring.coreos.com>",
+			expected: "get prometheuses.monitoring.coreos.com"},
+		{input: "get pods --cluster-name <http://xyz.alpha-sense.org|xyz.alpha-sense.org>",
+			expected: "get pods --cluster-name xyz.alpha-sense.org"},
+		{input: "get pods -n=default",
+			expected: "get pods -n=default"},
+		{input: "get pods",
+			expected: "get pods"},
 	}
 
 	for _, ts := range tests {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -83,3 +83,25 @@ func TestContains(t *testing.T) {
 		t.Errorf("expected: %v, got: %v", expected, got)
 	}
 }
+
+func TestRemoveHypelink(t *testing.T) {
+
+	type test struct {
+		input    string
+		expected string
+	}
+
+	tests := []test{
+		{input: "get <http://prometheuses.monitoring.coreos.com|prometheuses.monitoring.coreos.com> --cluster-name <http://xyz.alpha-sense.org|xyz.alpha-sense.org>", expected: "get prometheuses.monitoring.coreos.com --cluster-name xyz.alpha-sense.org"},
+		{input: "get <http://prometheuses.monitoring.coreos.com|prometheuses.monitoring.coreos.com>", expected: "get prometheuses.monitoring.coreos.com"},
+		{input: "get pods --cluster-name <http://xyz.alpha-sense.org|xyz.alpha-sense.org>", expected: "get pods --cluster-name xyz.alpha-sense.org"},
+		{input: "get pods -n=default", expected: "get pods -n=default"},
+	}
+
+	for _, ts := range tests {
+		got := RemoveHyperlink(ts.input)
+		if got != ts.expected {
+			t.Errorf("expected: %v, got: %v", ts.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
When clustername is passed to botkube from command and if that clustername contains valid domain then slack automatically adds <http:// to the url  
eg.  
if command is `@BotKube get pods --cluster-name xyz.alpha-sense.org`  then in botkube we get cluster name as `<http://xyz.alpha-sense.org|xyz.alpha-sense.org>`

#### Solution:
Added small logic in executor code to remove the unwanted string

Fixes https://github.com/infracloudio/botkube/issues/460
