### PR TITLE
Adding privileged, allowPrivilegedEscalation and readOnlyRootFilesyst…

### DIFF
--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{ end }}
           volumeMounts:
             - name: config-volume
               mountPath: "/config"
@@ -74,7 +78,9 @@ spec:
             secretName: {{ include "botkube.fullname" . }}-certificate-secret
       {{ end }}
       {{- if .Values.securityContext }}
-      {{- toYaml .Values.securityContext | nindent 12 }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
       {{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -74,9 +74,7 @@ spec:
             secretName: {{ include "botkube.fullname" . }}-certificate-secret
       {{ end }}
       {{- if .Values.securityContext }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      {{- toYaml .Values.securityContext | nindent 12 }}
       {{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -26,6 +26,8 @@ podSecurityPolicy:
 securityContext:
   runAsUser: 101
   runAsGroup: 101
+
+containerSecurityContext:
   privileged: false
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -26,6 +26,9 @@ podSecurityPolicy:
 securityContext:
   runAsUser: 101
   runAsGroup: 101
+  privileged: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
 
 # set one of the log levels- info, warn, debug, error, fatal, panic
 logLevel: info


### PR DESCRIPTION
Adding privileged, allowPrivilegedEscalation and readOnlyRootFilesystem to container security context, also adjusting deployment.yaml

##### ISSUE TYPE
- Feature Pull Request
 

##### SUMMARY
Need to add more granular control to the container's security context. I'd need to add these extra attributes as well as liveness and readiness probes. Is this is something that can be included in the code? 
thank you !
