### PR TITLE
fix: download the correct arch-specific kubectl

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -27,7 +27,12 @@ LABEL name="botkube" \
     description="BotKube is a messaging bot for monitoring and debugging Kubernetes clusters"
 
 COPY botkube /usr/local/bin/botkube
-COPY --from=bitnami/kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+# Download the latest kubectl in the appropriate architecture. Currently handles aarch64 (arm64) and x86_64 (amd64).
+RUN MACH=$(uname -m); if [[ ${MACH} == "aarch64" ]]; then ARCH=arm64; \
+    elif [[ ${MACH} == "x86_64" ]]; then ARCH=amd64; \
+    else echo "Unsupported arch: ${MACH}"; ARCH=${MACH}; fi; \
+    wget -O /usr/local/bin/kubectl "https://dl.k8s.io/release/$(wget -qO - https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl" && \
+    chmod +x /usr/local/bin/kubectl
 
 # Create Non Privileged user
 RUN addgroup --gid 1001 botkube && \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -30,6 +30,7 @@ COPY botkube /usr/local/bin/botkube
 # Download the latest kubectl in the appropriate architecture. Currently handles aarch64 (arm64) and x86_64 (amd64).
 RUN MACH=$(uname -m); if [[ ${MACH} == "aarch64" ]]; then ARCH=arm64; \
     elif [[ ${MACH} == "x86_64" ]]; then ARCH=amd64; \
+    elif [[ ${MACH} == "armv7l" ]]; then ARCH=arm; \
     else echo "Unsupported arch: ${MACH}"; ARCH=${MACH}; fi; \
     wget -O /usr/local/bin/kubectl "https://dl.k8s.io/release/$(wget -qO - https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl" && \
     chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fetches the current latest stable kubectl directly from the upstream.

An alternate approach would be to copy from `rancher/kubectl` but that requires explicit versioning.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->

<!--- Please list dependencies added with your change also -->

Fixes #516 
