### PR TITLE
Update Base Image to alpine 3.14.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,7 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM alpine:3.12
+FROM alpine:3.14.2
 ARG botkube_version="dev"
 LABEL name="botkube" \
     version="${botkube_version}" \


### PR DESCRIPTION
This release includes fixes for openssl CVE-2021-3711 and CVE-2021-3712.
https://alpinelinux.org/posts/Alpine-3.14.2-released.html

##### ISSUE TYPE
 - Bug fix Pull Request
 
Fixes #523 
