### PR TITLE
[CI] Fix goreleaser build with latest tags

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -30,6 +30,8 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         install-only: true
+        # Newer goreleaser version doesn't allow builds with "latest" tag
+        version: v0.179.0
     - name: Run GoReleaser
       run: make release-snapshot
     - name: Install Helm


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

##### ISSUE TYPE
 - Bug fix Pull Request


##### SUMMARY
New goreleaser versions doesn't allow builds with "latest" tags. This PR pins the goreleaser version in CI to prevent it from failure.
