### PR TITLE
feat(helm): allow to set deployment annotations

### DIFF
--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     component: controller
     app: botkube
+  annotations:
+    {{- if .Values.deployment.annotations }}
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -362,6 +362,9 @@ serviceMonitor:
   port: metrics
   labels: {} 
 
+deployment:
+  annotations: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Allow to set deployment annotations in helm chart.

Fixes #536

##### Remarks

I hesitated to use `extraAnnotations`, but when I look at other official helm charts most of the time they use different values for pods and deployments annotations. 

Imho we should also rename `extraAnnotations` to `podAnnotations` but would be a breaking change so I left it as it was.