### PR TITLE
fix: Failed to analyze an event whose lastTimestamp is null (#548)

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -123,6 +123,10 @@ func New(object interface{}, eventType config.EventType, resource, clusterName s
 		event.Count = eventObj.Count
 		event.Action = eventObj.Action
 		event.TimeStamp = eventObj.LastTimestamp.Time
+		t := time.Time{}
+		if eventObj.LastTimestamp.Time == t {
+			event.TimeStamp = eventObj.EventTime.Time
+		}
 	}
 	return event
 }


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### SUMMARY
The lastTimestamp field of the event is sometimes null and sometimes not empty, but these are normal, just because the old and new APIS are called differently. So we need to add a judgment here, using the EventTime field if lastTimestamp is empty

Fixes #548 
