### PR TITLE
Update base image to address busybox CVEs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,7 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM alpine:3.14.2
+FROM alpine:3.14.3
 ARG botkube_version="dev"
 LABEL name="botkube" \
     version="${botkube_version}" \


### PR DESCRIPTION
Please make a release, maintainers!

##### ISSUE TYPE
Mandatory security update

##### SUMMARY
Addresses:


  | CVE-2021-42378 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42379 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42380 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42381 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42382 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42383 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42384 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42385 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42386 | HIGH | busybox | 1.31.1-r20 | 1.31.1-r21
  | CVE-2021-42374 | MEDIUM | busybox | 1.31.1-r20 | 1.31.1-r21






