### PR TITLE
Ignore  error of type not found in resource

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -34,6 +34,7 @@ import (
 	log "github.com/infracloudio/botkube/pkg/log"
 
 	coreV1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -275,6 +276,10 @@ func ExtractAnnotationsFromEvent(obj *coreV1.Event) map[string]string {
 	}
 	annotations, err := DynamicKubeClient.Resource(gvr).Namespace(obj.InvolvedObject.Namespace).Get(context.Background(), obj.InvolvedObject.Name, metaV1.GetOptions{})
 	if err != nil {
+		// IgnoreNotFound returns nil on NotFound errors.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		log.Error(err)
 		return nil
 	}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
After using Botkube for some time, I found a large number of "not found" errors when querying logs for troubleshooting. 
![image](https://user-images.githubusercontent.com/46153551/147660719-bfc76aa6-2912-44ef-a762-ebe8104ff764.png)


Following the code, it turns out that these errors are caused by the Informer cache but are actually normal. Controller-runtime does a similar thing.
https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/interfaces.go
```
// IgnoreNotFound returns nil on NotFound errors.
// All other values that are not NotFound errors or nil are returned unmodified.
func IgnoreNotFound(err error) error {
	if apierrors.IsNotFound(err) {
		return nil
	}
	return err
}
```



