### PR TITLE
perf: Use `strings.EqualFold` for string comparison

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -399,7 +399,7 @@ func CheckOperationAllowed(eventMap map[EventKind]bool, namespace string, resour
 // Contains tells whether a contains x.
 func Contains(a []string, x string) bool {
 	for _, n := range a {
-		if strings.ToLower(x) == strings.ToLower(n) {
+		if strings.EqualFold(x, n) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description

`strings.ToLower/strings.ToUpper` will have to allocate memory for the new strings, as well as convert both strings fully, even if they differ on the very first byte. On the other hand, `strings.EqualFold` compares the strings one character at a time. It doesn't need to create two intermediate strings and can return as soon as the first non-matching character has been found.
