### PR TITLE
Replace latest tag with v9.99.9-dev in builds

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -30,8 +30,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         install-only: true
-        # Newer goreleaser version doesn't allow builds with "latest" tag
-        version: v0.179.0
+        version: latest
     - name: Run GoReleaser
       run: make release-snapshot
     - name: Install Helm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,12 @@ Now you can build and run BotKube by one of the following ways
 
 ### Build the container image
 
-1. This will build BotKube and create a new container image tagged as `infracloudio/botkube:latest`
+1. This will build BotKube and create a new container image tagged as `ghcr.io/infracloudio/botkube:v9.99.9-dev`
    ```sh
    $ make build
    $ make container-image
-   $ docker tag infracloudio/botkube:latest-amd64 <your_account>/botkube:latest
-   $ docker push <your_account>/botkube:latest
+   $ docker tag ghcr.io/infracloudio/botkube:v9.99.9-dev-amd64 <your_account>/botkube:v9.99.9-dev
+   $ docker push <your_account>/botkube:v9.99.9-dev
    ```
    Where `<your_account>` is Docker hub account to which you can push the image
 
@@ -53,7 +53,7 @@ Now you can build and run BotKube by one of the following ways
      --set settings.clustername=<CLUSTER_NAME> \
      --set settings.kubectl.enabled=<ALLOW_KUBECTL> \
      --set image.repository=<your_account>/botkube \
-     --set image.tag=latest \
+     --set image.tag=v9.99.9-dev \
      infracloudio/botkube
    ```
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ gorelease:
 	@echo "Publishing release with goreleaser"
 	@./hack/goreleaser.sh release
 
-# Build project and push dev images with latest tag
+# Build project and push dev images with v9.99.9-dev tag
 release-snapshot:
 	@./hack/goreleaser.sh release_snapshot
 

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -29,18 +29,18 @@ prepare() {
 
 release_snapshot() {
   prepare
-  export GORELEASER_CURRENT_TAG=latest
+  export GORELEASER_CURRENT_TAG=v9.99.9-dev
   goreleaser release --rm-dist --snapshot --skip-publish
   # Push images
-  docker push ghcr.io/infracloudio/botkube:latest-amd64
-  docker push ghcr.io/infracloudio/botkube:latest-arm64
-  docker push ghcr.io/infracloudio/botkube:latest-armv7
+  docker push ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-amd64
+  docker push ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-arm64
+  docker push ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-armv7
   # Create manifest
-  docker manifest create ghcr.io/infracloudio/botkube:latest \
-    --amend ghcr.io/infracloudio/botkube:latest-amd64 \
-    --amend ghcr.io/infracloudio/botkube:latest-arm64 \
-    --amend ghcr.io/infracloudio/botkube:latest-armv7
-  docker manifest push ghcr.io/infracloudio/botkube:latest
+  docker manifest create ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG} \
+    --amend ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-amd64 \
+    --amend ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-arm64 \
+    --amend ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-armv7
+  docker manifest push ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}
 }
 
 build() {
@@ -49,7 +49,7 @@ build() {
     -v $PWD:/go/src/github.com/infracloudio/botkube \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -w /go/src/github.com/infracloudio/botkube \
-    -e GORELEASER_CURRENT_TAG=latest \
+    -e GORELEASER_CURRENT_TAG=v9.99.9-dev \
     goreleaser/goreleaser release --rm-dist --snapshot --skip-publish
 }
 
@@ -69,7 +69,7 @@ usage() {
 Usage: ${0} [build|release|release_snapshot]
 Where,
   build: Builds project with goreleaser without pushing images.
-  release_snapshot: Builds project without publishing release. It builds and pushes BotKube image with latest image tag.
+  release_snapshot: Builds project without publishing release. It builds and pushes BotKube image with v9.99.9-dev image tag.
   release: Makes and published release to GitHub
 EOM
     exit 1


### PR DESCRIPTION
Signed-off-by: Prasad Ghangal <prasad.ghangal@gmail.com>

##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY

The latest goreleaser doesn't support non-semver image tags. 
This PR replaces `latest` tags with `v9.99.9-dev` to support latest version of goreleaser

