### PR TITLE
fix: Failed to analyze an event whose lastTimestamp is null

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -123,6 +123,11 @@ func New(object interface{}, eventType config.EventType, resource, clusterName s
 		event.Count = eventObj.Count
 		event.Action = eventObj.Action
 		event.TimeStamp = eventObj.LastTimestamp.Time
+		// Compatible with events.k8s.io/v1
+		if eventObj.LastTimestamp.IsZero() {
+			event.TimeStamp = eventObj.Series.LastObservedTime.Time
+			event.Count = eventObj.Series.Count
+		}
 	}
 	return event
 }


### PR DESCRIPTION
##### ISSUE TYPE
- Bug fix Pull Request
##### SUMMARY
The lastTimestamp field of the event is sometimes null and sometimes not empty, but these are normal, just because the old and new APIS are called differently. So we need to add a judgment here, using the EventTime field if lastTimestamp is empty

Fixes https://github.com/infracloudio/botkube/issues/548

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
PR comment; and describe briefly what the change does.
-->
