### PR TITLE
Fix [event.go 128] invalid memory address or nil pointer 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,58 +1,59 @@
+project_name: botkube
 before:
   hooks:
     - go mod download
 builds:
-- id: botkube
-  binary: botkube
-  main: cmd/botkube/main.go
-  ldflags: &ldflags
-  - -s -w
-    -X github.com/infracloudio/botkube/pkg/version.Version={{ .Tag }}
-    -X github.com/infracloudio/botkube/pkg/version.GitCommitID={{ .Commit }}
-    -X github.com/infracloudio/botkube/pkg/version.BuildDate={{ .Date }}
-  env:
-  - CGO_ENABLED=0
-  goos:
-    - linux
-  goarch:
-    - amd64
-    - arm
-    - arm64
-  goarm:
-    - 7
+  - id: botkube
+    binary: botkube
+    main: cmd/botkube/main.go
+    ldflags: &ldflags
+      - -s -w
+        -X github.com/infracloudio/botkube/pkg/version.Version={{ .Tag }}
+        -X github.com/infracloudio/botkube/pkg/version.GitCommitID={{ .Commit }}
+        -X github.com/infracloudio/botkube/pkg/version.BuildDate={{ .Date }}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
 snapshot:
   name_template: "{{ .Tag }}"
 changelog:
   skip: true
 dockers:
-- image_templates:
-  - 'ghcr.io/infracloudio/botkube:{{ .Tag }}-amd64'
-  use: buildx
-  dockerfile: 'build/Dockerfile'
-  build_flag_templates:
-  - "--platform=linux/amd64"
-  - "--build-arg=botkube_version={{ .Tag }}"
-- image_templates:
-  - 'ghcr.io/infracloudio/botkube:{{ .Tag }}-arm64'
-  use: buildx
-  goarch: arm64
-  dockerfile: 'build/Dockerfile'
-  build_flag_templates:
-  - "--platform=linux/arm64"
-  - "--build-arg=botkube_version={{ .Tag }}"
-- image_templates:
-  - 'ghcr.io/infracloudio/botkube:{{ .Tag }}-armv7'
-  use: buildx
-  goarch: arm
-  goarm: 7
-  dockerfile: 'build/Dockerfile'
-  build_flag_templates:
-  - "--platform=linux/arm"
-  - "--build-arg=botkube_version={{ .Tag }}"
+  - image_templates:
+      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-amd64"
+    use: buildx
+    dockerfile: "build/Dockerfile"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=botkube_version={{ .Tag }}"
+  - image_templates:
+      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-arm64"
+    use: buildx
+    goarch: arm64
+    dockerfile: "build/Dockerfile"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=botkube_version={{ .Tag }}"
+  - image_templates:
+      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-armv7"
+    use: buildx
+    goarch: arm
+    goarm: 7
+    dockerfile: "build/Dockerfile"
+    build_flag_templates:
+      - "--platform=linux/arm"
+      - "--build-arg=botkube_version={{ .Tag }}"
 
 docker_manifests:
-- name_template: ghcr.io/infracloudio/botkube:{{ .Tag }}
-  image_templates:
-  - ghcr.io/infracloudio/botkube:{{ .Tag }}-amd64
-  - ghcr.io/infracloudio/botkube:{{ .Tag }}-arm64
-  - ghcr.io/infracloudio/botkube:{{ .Tag }}-armv7
+  - name_template: ghcr.io/infracloudio/botkube:{{ .Tag }}
+    image_templates:
+      - ghcr.io/infracloudio/botkube:{{ .Tag }}-amd64
+      - ghcr.io/infracloudio/botkube:{{ .Tag }}-arm64
+      - ghcr.io/infracloudio/botkube:{{ .Tag }}-armv7

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -124,7 +124,7 @@ func New(object interface{}, eventType config.EventType, resource, clusterName s
 		event.Action = eventObj.Action
 		event.TimeStamp = eventObj.LastTimestamp.Time
 		// Compatible with events.k8s.io/v1
-		if eventObj.LastTimestamp.IsZero() {
+		if eventObj.LastTimestamp.IsZero() && !eventObj.Series.LastObservedTime.IsZero() {
 			event.TimeStamp = eventObj.Series.LastObservedTime.Time
 			event.Count = eventObj.Series.Count
 		}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -110,6 +110,7 @@ func New(object interface{}, eventType config.EventType, resource, clusterName s
 
 	if objectTypeMeta.Kind == "Event" {
 		var eventObj coreV1.Event
+		var eventSeriesObj coreV1.EventSeries
 		err := utils.TransformIntoTypedObject(object.(*unstructured.Unstructured), &eventObj)
 		if err != nil {
 			log.Errorf("Unable to transform object type: %v, into type: %v", reflect.TypeOf(object), reflect.TypeOf(eventObj))
@@ -124,9 +125,9 @@ func New(object interface{}, eventType config.EventType, resource, clusterName s
 		event.Action = eventObj.Action
 		event.TimeStamp = eventObj.LastTimestamp.Time
 		// Compatible with events.k8s.io/v1
-		if eventObj.LastTimestamp.IsZero() && !eventObj.Series.LastObservedTime.IsZero() {
-			event.TimeStamp = eventObj.Series.LastObservedTime.Time
-			event.Count = eventObj.Series.Count
+		if eventObj.LastTimestamp.IsZero() && !eventSeriesObj.LastObservedTime.IsZero() {
+			event.TimeStamp = eventSeriesObj.LastObservedTime.Time
+			event.Count = eventSeriesObj.Count
 		}
 	}
 	return event


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY
Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)

event.go : line 128 
event.TimeStamp = eventObj.Series.LastObservedTime.Time

was giving nil pointer.
