### PR TITLE
Support extra K8s resources creation during Helm chart installation

### DIFF
--- a/helm/botkube/README.md
+++ b/helm/botkube/README.md
@@ -118,3 +118,4 @@ serviceAccount:
 | serviceMonitor.path | string | `"/metrics"` |  |
 | serviceMonitor.port | string | `"metrics"` |  |
 | tolerations | list | `[]` |  |
+| extraObjects | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |

--- a/helm/botkube/templates/extraobjects.yaml
+++ b/helm/botkube/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (. | toYaml) $ }}
+{{- end }}

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -427,21 +427,25 @@ serviceAccount:
 
 # Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources.
 extraObjects: []
-# e.g to create a ClusterRoleBinding resource without creating a dedicated ClusterRole:
-# - apiVersion: rbac.authorization.k8s.io/v1
-#   kind: ClusterRoleBinding
-#   metadata:
-#     name: {{ include "botkube.fullname" . }}-clusterrolebinding
-#     labels:
-#       app.kubernetes.io/name: {{ include "botkube.name" . }}
-#       helm.sh/chart: {{ include "botkube.chart" . }}
-#       app.kubernetes.io/instance: {{ .Release.Name }}
-#       app.kubernetes.io/managed-by: {{ .Release.Service }}
-#   roleRef:
-#     apiGroup: rbac.authorization.k8s.io
-#     kind: ClusterRole
-#     name: {{ .Values.extraClusterRoleName }}
-#   subjects:
-#   - kind: ServiceAccount
-#     name: {{ include "botkube.serviceAccountName" . }}
-#     namespace: {{ .Release.Namespace }}
+# For example, to create a ClusterRoleBinding resource without creating a dedicated ClusterRole, uncomment the following snippet.
+# NOTE: While running Helm install/upgrade with this sample snippet uncommented, make sure to set the following values:
+#    1. `rbac.create: false`
+#    2.`extraClusterRoleName: {clusterRole}`, where {clusterRole} is a given ClusterRole name (e.g. `cluster-admin`).
+#
+#    - apiVersion: rbac.authorization.k8s.io/v1
+#      kind: ClusterRoleBinding
+#      metadata:
+#        name: "{{ include \"botkube.fullname\" . }}-clusterrolebinding"
+#        labels:
+#          app.kubernetes.io/name: "{{ include \"botkube.name\" . }}"
+#          helm.sh/chart: "{{ include \"botkube.chart\" . }}"
+#          app.kubernetes.io/instance: "{{ .Release.Name }}"
+#          app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+#      roleRef:
+#        apiGroup: rbac.authorization.k8s.io
+#        kind: ClusterRole
+#        name: "{{ .Values.extraClusterRoleName }}"
+#      subjects:
+#      - kind: ServiceAccount
+#        name: "{{ include \"botkube.serviceAccountName\" . }}"
+#        namespace: "{{ .Release.Namespace }}"

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -424,3 +424,24 @@ serviceAccount:
   #name:
   # annotations for the service account
   annotations: {}
+
+# Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources.
+extraObjects: []
+# e.g to create a ClusterRoleBinding resource without creating a dedicated ClusterRole:
+# - apiVersion: rbac.authorization.k8s.io/v1
+#   kind: ClusterRoleBinding
+#   metadata:
+#     name: {{ include "botkube.fullname" . }}-clusterrolebinding
+#     labels:
+#       app.kubernetes.io/name: {{ include "botkube.name" . }}
+#       helm.sh/chart: {{ include "botkube.chart" . }}
+#       app.kubernetes.io/instance: {{ .Release.Name }}
+#       app.kubernetes.io/managed-by: {{ .Release.Service }}
+#   roleRef:
+#     apiGroup: rbac.authorization.k8s.io
+#     kind: ClusterRole
+#     name: {{ .Values.extraClusterRoleName }}
+#   subjects:
+#   - kind: ServiceAccount
+#     name: {{ include "botkube.serviceAccountName" . }}
+#     namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY

- Support extra K8s resources creation during Helm chart installation


Additional pull request that updates documentation: https://github.com/infracloudio/botkube-docs/pull/72

Resolves #561 

##### TESTING

Clone this repository (check out the branch) - you can use https://cli.github.com/

Create namespace:

```bash
kubectl create ns botkube
```

Run a dry-run of botkube installation with custom values
```bash
cat > /tmp/values.yaml << ENDOFFILE
extraObjects: 
  - apiVersion: rbac.authorization.k8s.io/v1
    kind: ClusterRoleBinding
    metadata:
      name: "{{ include \"botkube.fullname\" . }}-clusterrolebinding"
      labels:
        app.kubernetes.io/name: "{{ include \"botkube.name\" . }}"
        helm.sh/chart: "{{ include \"botkube.chart\" . }}"
        app.kubernetes.io/instance: "{{ .Release.Name }}"
        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: "{{ .Values.extraClusterRoleName }}"
    subjects:
    - kind: ServiceAccount
      name: "{{ include \"botkube.serviceAccountName\" . }}"
      namespace: "{{ .Release.Namespace }}"
rbac:
  create: false
extraClusterRoleName: cluster-admin
ENDOFFILE

helm install botkube --namespace botkube -f /tmp/values.yaml ./helm/botkube --dry-run
```

Observe the ClusterResourceBinding resource bound to `cluster-admin` ClusterRole in output.
