### PR TITLE
Fix writing cache for kubectl exec commands

### DIFF
--- a/deploy-all-in-one-tls.yaml
+++ b/deploy-all-in-one-tls.yaml
@@ -374,6 +374,8 @@ spec:
               mountPath: "/config"
             - name: certs
               mountPath: "/etc/ssl/certs"
+            - name: cache
+              mountPath: "/.kube/cache"              
           env:
             - name: CONFIG_PATH
               value: "/config/"
@@ -391,6 +393,8 @@ spec:
         - name: certs
           secret:
             secretName: botkube-certificate-secret
+        - name: cache
+          emptyDir: {}  
       # run as non privileged user
       securityContext:
         runAsUser: 101

--- a/deploy-all-in-one.yaml
+++ b/deploy-all-in-one.yaml
@@ -362,6 +362,8 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: "/config"
+            - name: cache
+              mountPath: "/.kube/cache"                     
           env:
             - name: CONFIG_PATH
               value: "/config/"
@@ -376,6 +378,8 @@ spec:
                 name: botkube-configmap
             - secret:
                 name: botkube-communication-secret
+        - name: cache
+          emptyDir: {}                  
       # run as non privileged user
       securityContext:
         runAsUser: 101

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -57,8 +57,11 @@ spec:
           {{ end }}
           {{- if .Values.kubeconfig.enabled }}
             - name: kubeconfig
-              mountPath: "/.kube"
+              mountPath: "/.kube/config"
+              subPath: config
           {{ end }}
+            - name: cache
+              mountPath: "/.kube/cache"
           env:
             - name: CONFIG_PATH
               value: "/config/"
@@ -102,6 +105,8 @@ spec:
             secretName: {{ .Values.kubeconfig.existingSecret }}
             {{- end }}
       {{ end }}
+        - name: cache
+          emptyDir: {}    
       {{- if .Values.securityContext }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}


### PR DESCRIPTION
##### ISSUE TYPE

 - Bug fix Pull Request

##### SUMMARY

- Fix writing cache for kubectl exec commands

Fixes #564 

##### NOTES

Initially I wanted to reuse cache directory both for kubectl executor and cachedDiscoveryClient used for dynamic K8s client, to avoid doing dozens of calls to discover API groups twice - firstly when setting up informers, and next, when executing `kubectl` commands (when it is enabled in settings).

Currently, the cachedDiscoveryClient is in-memory based. I converted it to disk-based one, using the same path for cache as `kubectl`: https://github.com/pkosiec/botkube/compare/fix-kubectl-cache-write...pkosiec:share-kubectl-cache?expand=1

However, I'm not really sure if that brings any significant value - digging deeper, both clients read/write the same cache even if they weren't created by a given client (https://github.com/kubernetes/client-go/blob/v0.20.5/discovery/cached/disk/cached_discovery.go#L136), but after reading it it will mark cache as "not fresh anymore", which will cause cache refresh (https://github.com/kubernetes/client-go/blob/v0.20.5/discovery/cached/disk/cached_discovery.go#L169) until created files are included in "ourFiles" map. So in my understanding this will result in the same thing as separate cache storages. After discovering that I reverted the changes.

If I am wrong and you see some value in these changes, let me know - I can apply them onto this PR 🙂 

##### TESTING
Clone this repository (check out the branch) - you can use https://cli.github.com/

Create namespace:

```bash
kubectl create ns botkube
```

Install BotKube and configure it with any of services (I used Mattermost following the documentation: https://www.botkube.io/installation/mattermost/). Make sure you use local Helm chart for the installation

I used the following values for local Mattermost configuration:
```bash
communications:
  mattermost:
    botName: BotKube
    channel: general
    enabled: true
    team: admin
    token: token
    url: http://mattermost-team-edition.default:8065
config:
  settings:
    clustername: sample
    kubectl:
      enabled: true
ENDOFFILE

helm install botkube --namespace botkube -f /tmp/values.yaml ./helm/botkube --wait
```

Previously, every command with the highest verbosity level, such as `@BotKube get po -v=10` contained the following error in logs:
```
I0517 14:08:54.368841      24 cached_discovery.go:87] failed to write cache to /.kube/cache/discovery/10.43.0.1_443/v1/serverresources.json due to mkdir /.kube: read-only file system
```

Now, there are different data:

```
I0518 13:39:12.702581      23 cached_discovery.go:71] returning cached discovery info from /.kube/cache/discovery/10.43.0.1_443/apiextensions.k8s.io/v1/serverresources.json
I0518 13:39:12.702696      23 cached_discovery.go:71] returning cached discovery info from /.kube/cache/discovery/10.43.0.1_443/apps/v1/serverresources.json
I0518 13:39:12.702702      23 cached_discovery.go:71] returning cached discovery info from /.kube/cache/discovery/10.43.0.1_443/flowcontrol.apiserver.k8s.io/v1beta1/serverresources.json
I0518 13:39:12.702764      23 cached_discovery.go:71] returning cached discovery info from /.kube/cache/discovery/10.43.0.1_443/scheduling.k8s.io/v1/serverresources.json
I0518 13:39:12.702864      23 cached_discovery.go:71] returning cached discovery info from /.kube/cache/discovery/10.43.0.1_443/events.k8s.io/v1/serverresources.json
# (...)
```

which confirms the solution works.

You can also install Mattermost with base64-encoded Kubeconfig to see that this change didn't break anything.

Append `/tmp/values.yaml`, and put:
```
kubeconfig:
  enabled: true
  base64Config: {base64-encoded your kubeconfig from local machine; remember to edit your kubeconfig and point to https://kubernetes.default before pasting it here}
```