### PR TITLE
Do not log full Slack event details in case of unmarshalling error

### DIFF
--- a/pkg/bot/export_test.go
+++ b/pkg/bot/export_test.go
@@ -1,0 +1,5 @@
+package bot
+
+func (b *SlackBot) StripUnmarshallingErrEventDetails(errMessage string) string {
+	return b.stripUnmarshallingErrEventDetails(errMessage)
+}

--- a/pkg/bot/slack_test.go
+++ b/pkg/bot/slack_test.go
@@ -1,0 +1,53 @@
+package bot_test
+
+import (
+	"fmt"
+	"github.com/infracloudio/botkube/pkg/bot"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSlackBot_StripUnmarshallingErrEventDetails(t *testing.T) {
+	//given
+	sampleEvent := `{"type":"user_huddle_changed","user":{"id":"id","team_id":"team_id"}, "event_ts":"1652949120.004700"}`
+
+	testCases := []struct {
+		Name     string
+		Input    string
+		Expected string
+	}{
+		{
+			Name:     "Unmapped event",
+			Input:    fmt.Sprintf(`RTM Error: Received unmapped event "user_huddle_changed": %s`, sampleEvent),
+			Expected: `RTM Error: Received unmapped event "user_huddle_changed"`,
+		},
+		{
+			Name:     "Unmarshalling error message",
+			Input:    fmt.Sprintf(`RTM Error: Could not unmarshall event "user_huddle_changed": %s`, sampleEvent),
+			Expected: `RTM Error: Could not unmarshall event "user_huddle_changed"`,
+		},
+		{
+			Name:     "JSON unmarshal error",
+			Input:    "cannot unmarshal bool into Go value of type string",
+			Expected: "cannot unmarshal bool into Go value of type string",
+		},
+		{
+			Name: "JSON unmarshal error with colons",
+			// this is a real error when doing json.Unmarshal([]byte(`":::"`), &time)
+			Input:    `parsing time "":::"" as ""2006-01-02T15:04:05Z07:00"": cannot parse ":::"" as "2006"`,
+			Expected: `parsing time "":::"" as ""2006-01-02T15:04:05Z07:00"": cannot parse ":::"" as "2006"`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			slackBot := &bot.SlackBot{}
+
+			// when
+			actual := slackBot.StripUnmarshallingErrEventDetails(testCase.Input)
+
+			// then
+			assert.Equal(t, testCase.Expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY

- Do not log full Slack event details in case of unmarshalling error

This is an issue of the upstream library. While I prepared a workaround, I also prepared a simple change in `slack-go/slack` repo: https://github.com/slack-go/slack/pull/1067

**NOTE:** This pull request depends on #582. Please merge #582 first, and I will rebase this one.

Actual changes on this PR: https://github.com/infracloudio/botkube/commit/7813821947c6cbcc7d7040f3fb1a70ed57e9a4f6

Fixes #579

##### TESTING

See the original issue for testing instruction: #579
You can use `pkosiec/botkube:slack-unmarshall-err` Docker image for testing the workaround.
Once you run my image and try to reproduce the issue, you'll see in the logs:

```
ERRO[2022-05-19T16:00:57Z] Slack unmarshalling error: RTM Error: Received unmapped event "user_huddle_changed"
ERRO[2022-05-19T16:00:57Z] Slack unmarshalling error: RTM Error: Received unmapped event "sh_room_join"
ERRO[2022-05-19T16:01:00Z] Slack unmarshalling error: RTM Error: Received unmapped event "sh_room_leave"
``` 
