### PR TITLE
Set event TimeStamp if K8s event Series is not nil

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -124,7 +124,7 @@ func New(object interface{}, eventType config.EventType, resource, clusterName s
 		event.Action = eventObj.Action
 		event.TimeStamp = eventObj.LastTimestamp.Time
 		// Compatible with events.k8s.io/v1
-		if eventObj.LastTimestamp.IsZero() {
+		if eventObj.LastTimestamp.IsZero() && eventObj.Series != nil {
 			event.TimeStamp = eventObj.Series.LastObservedTime.Time
 			event.Count = eventObj.Series.Count
 		}


### PR DESCRIPTION

##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY

This PR fixes the bug where BotKube is crashing while building events.
Add a condition to check the event.Series object is nil before accessing its field.