### PR TITLE
Add and describe opt to specify sensitive data via external secrets

### DIFF
--- a/helm/botkube/templates/_helpers.tpl
+++ b/helm/botkube/templates/_helpers.tpl
@@ -45,3 +45,7 @@ Create the name of the service account to use
 {{- define "botkube.CommunicationsSecretName" -}}
 {{- .Values.communications.existingSecretName | default (printf "%s-communication-secret" (include "botkube.fullname" .)) -}}
 {{- end -}}
+
+{{- define "botkube.SSLCertSecretName" -}}
+{{- .Values.config.ssl.existingSecretName | default (printf "%s-certificate-secret" (include "botkube.fullname" .)) -}}
+{{- end -}}

--- a/helm/botkube/templates/deployment.yaml
+++ b/helm/botkube/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
       {{- if .Values.config.ssl.enabled }}
         - name: certs
           secret:
-            secretName: {{ include "botkube.fullname" . }}-certificate-secret
+            secretName: {{ include "botkube.SSLCertSecretName" . }}
       {{ end }}
       {{- if .Values.kubeconfig.enabled }}
         - name: kubeconfig
@@ -106,7 +106,7 @@ spec:
             {{- end }}
       {{ end }}
         - name: cache
-          emptyDir: {}    
+          emptyDir: {}
       {{- if .Values.securityContext }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/helm/botkube/templates/sslcert.yaml
+++ b/helm/botkube/templates/sslcert.yaml
@@ -1,9 +1,8 @@
-{{- if .Values.config.ssl.enabled }}
-
+{{- if and .Values.config.ssl.enabled .Values.config.ssl.cert }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "botkube.fullname" . }}-certificate-secret
+  name: {{ include "botkube.SSLCertSecretName" . }}
   labels:
     app.kubernetes.io/name: {{ include "botkube.name" . }}
     helm.sh/chart: {{ include "botkube.chart" . }}
@@ -11,5 +10,4 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   ca-certificates.crt: {{ .Files.Get (printf "%s" .Values.config.ssl.cert) | b64enc }}
-
 {{ end }}

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -34,14 +34,18 @@ containerSecurityContext:
   readOnlyRootFilesystem: true
 
 kubeconfig:
-  # If true, enables overriding the kubernetes auth
+  # If true, enables overriding the kubernetes auth.
+  # NOTE: Remember to set automountServiceAccountToken to false.
   enabled: false
   # A base64 encoded kubeconfig that will be stored in a secret, mounted to the pod, and specified in the KUBECONFIG environment variable.
   base64Config: ""
   # A secret containing a kubeconfig to use.
+  # Secret format:
+  #  data:
+  #    config: {base64_encoded_kubeconfig}
   existingSecret: ""
 
-# Use this to override the default behavior of the service account. May be necessary to set this to false when using kubeconfig.enabled
+# Use this to override the default behavior of the service account. It MUST be disabled when using kubeconfig.enabled.
 automountServiceAccountToken: true
 
 # set one of the log levels- info, warn, debug, error, fatal, panic
@@ -256,9 +260,18 @@ config:
   # about the best practices for the created resource
   recommendations: true
 
-  ssl:                                           # For using custom SSL certificates
-    enabled: false                               # Set to true and specify cert path in the next line after uncommenting
-    #cert:                                       # SSL Certificate file e.g certs/my-cert.crt
+  # For using custom SSL certificates
+  ssl:
+    # Set to true and specify cert path in the next line after uncommenting
+    enabled: false
+    # Using existing SSL secret. It MUST be in botkube Namespace.
+    # Secret format:
+    #  data:
+    #    ca-certificates.crt: {base64_encoded_ssl_cert}
+    #existingSecretName: ""
+
+    # SSL Certificate file e.g certs/my-cert.crt
+    #cert:
 
   # Setting to support multiple clusters
   settings:
@@ -286,15 +299,21 @@ config:
 # Communication settings
 communications:
 
-  # Using existing Communication secret
+  # Using existing Communication secret. It MUST be in botkube Namespace.
+  # Secret format:
+  #  stringData:
+  #    comm_config.yaml: |
+  #      communications:
+  #        # Here specify settings for each app, like Slack, Mattermost etc.
+  #        # NOTE: Use setting format visible below.
   existingSecretName: ""
-  
+
   # Settings for Slack
   slack:
     enabled: false
     channel: 'SLACK_CHANNEL'                   # Slack channel name without '#' prefix where you have added BotKube and want to receive notifications in
     token: 'SLACK_API_TOKEN'
-    notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified) 
+    notiftype: short                           # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
 
   # Settings for Mattermost
   mattermost:
@@ -315,15 +334,14 @@ communications:
     notiftype: short
     port: 3978
 
-  
   # Settings for Discord
   discord:
     enabled: false
-    token: 'DISCORD_TOKEN'                      # BotKube Bot Token 
-    botid: 'DISCORD_BOT_ID'                     # BotKube Application Client ID 
-    channel: 'DISCORD_CHANNEL_ID'               # Discord Channel id for receiving BotKube alerts 
+    token: 'DISCORD_TOKEN'                      # BotKube Bot Token
+    botid: 'DISCORD_BOT_ID'                     # BotKube Application Client ID
+    channel: 'DISCORD_CHANNEL_ID'               # Discord Channel id for receiving BotKube alerts
     notiftype: short                            # Change notification type short/long you want to receive. notiftype is optional and Default notification type is short (if not specified)
-  
+
   # Settings for ELS
   elasticsearch:
     enabled: false
@@ -362,7 +380,7 @@ communications:
 service:
   name: metrics
   port: 2112
-  targetPort: 2112  
+  targetPort: 2112
 
 # Ingress settings to expose teams and lark endpoints
 ingress:
@@ -382,7 +400,7 @@ serviceMonitor:
   interval: 10s
   path: /metrics
   port: metrics
-  labels: {} 
+  labels: {}
 
 deployment:
   annotations: {}
@@ -403,7 +421,7 @@ extraEnv: []
 ## Extra environment variables to pass to the BotKube container, example HTTP_PROXY
 ## extraEnv:
 ##   HTTP_PROXY: <proxyURL>:<port>
-  
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request
 - Documentation Pull Request

##### SUMMARY

- Add option to specify external secret with SSL cert
- Document Secret format for `kubeconfig`, `ssl`, and `communication` settings.

Related issue: https://github.com/infracloudio/botkube/issues/480

##### TESTING

An  option to specify external secret with SSL cert can be tested with `helm template`:

1. Checkout this PR: `gh pr checkout 597`
2. Run with external Secret:
    ```bash
    helm template ./helm/botkube/ --namespace botkube --set config.ssl.enabled=true --set config.ssl.existingSecretName=external-ssl-cert
    ```
    See that there is only **one** Secret for communication, and for certs the `external-ssl-cert` name is used.

4. Run with auto created secret:
    ```bash
    helm template ./helm/botkube/ --namespace botkube --set config.ssl.enabled=true --set config.ssl.cert=ssl.crt
    ``` 
    See that there are **two** Secrets, one for communication and one for SSL.


Testing of already existing features were described in https://github.com/infracloudio/botkube/issues/480#issuecomment-1139559186