### PR TITLE
Add option to build&push image on PR via label

### DIFF
--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -1,0 +1,72 @@
+name: Publish BotKube image
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened, labeled ]
+    branches:
+      - "develop"
+
+env:
+  GO_VERSION: 1.18
+
+jobs:
+  publish:
+    name: Build and push
+    runs-on: ubuntu-latest
+
+    # Since external users do not have the permission to assign labels,
+    # this effectively requires repository owners to manually review the changes first.
+    if: contains(github.event.pull_request.labels.*.name, 'build-pr-image')
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
+          version: latest
+
+      - name: Run GoReleaser
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          make release_pr_snapshot
+
+      - name: Summary
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          cat > $GITHUB_STEP_SUMMARY << ENDOFFILE
+          ### BotKube image published successfully! :rocket:
+
+          To test BotKube with PR changes, run:
+
+              gh pr checkout ${PR_NUMBER}
+
+              helm install botkube -n botkube --create-namespace \\
+              --set image.repository=infracloudio/pr/botkube \\
+              --set image.tag=v${PR_NUMBER} \\
+              ./helm/botkube
+
+          ENDOFFILE

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ gorelease:
 release-snapshot:
 	@./hack/goreleaser.sh release_snapshot
 
+# Build project and push PR images with PR_NUMBER tag
+release_pr_snapshot:
+	@./hack/goreleaser.sh release_pr_snapshot
+
 # system checks
 system-check:
 	@echo "Checking system information"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY

Add an option to push the BotKube image automatically on PR. Because of   the security reasons, it's enabled only if the `build-pr-image` label is added—since external users do not have the permission to assign labels, this effectively requires repository owners to manually review the changes first.

Here is recorded demo https://www.loom.com/share/2f0fdc621a144d32861d83946bfff1d7 and repository on which I tested that change: https://github.com/mszostok/botkube/pulls

This PR will solve the problem with manual PR builds, e.g. we had that issue here:
- https://github.com/infracloudio/botkube/pull/601
- https://github.com/infracloudio/botkube/pull/593
- https://github.com/infracloudio/botkube/pull/582
- https://github.com/infracloudio/botkube/pull/583

Fixes #590 

#### After merge

A new label `build-pr-image` needs to be created.


#### Further improvements

1. Add `build-pr-image` automatically, for all trusted members _(org collaborators)_. As a result, we don't need to remember about that.
2. Add a comment about successfully pushed images directly under PR. It just simplifies the UX by removing one more mouse click.


#### Alternative solution

The alternative doesn't require manual action. However, it's more complicated.

See: https://github.com/infracloudio/botkube/compare/develop...mszostok:build-images-on-prs-v2?expand=1

To ensure that secrets won't be available for untrusted code, first we need to build the image and share it with the second job, which doesn't check out the untrusted code and can safely push an artifact to ghcr.io.



#### Security

This article describes it well: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/