### PR TITLE
Add option to build&push image on PR automatically

### DIFF
--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -5,6 +5,25 @@ on:
     types: [ opened, synchronize, reopened ]
     branches:
       - "develop"
+    paths-ignore:
+      - 'branding/**'
+      - 'design/**'
+      - 'helm/**'
+      - '.codespell-whitelist'
+      - '.gitignore'
+      - '.golangci.yml'
+      - '.mergify.yml'
+      - 'botkube-title.jpg'
+      - 'botkube_arch.jpg'
+      - 'CHANGELOG.md'
+      - 'CODE_OF_CONDUCT.md'
+      - 'comm_config.yaml'
+      - 'CONTRIBUTING.md'
+      - 'deploy-all-in-one.yaml'
+      - 'deploy-all-in-one-tls.yaml'
+      - 'LICENSE'
+      - 'README.md'
+      - 'resource_config.yaml'
 
 env:
   GO_VERSION: 1.18
@@ -47,7 +66,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.APP }}-${{github.sha}}
-          path: /tmp/
+          path: /tmp/*.tar
           retention-days: 1
 
   push-image:

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -1,0 +1,106 @@
+name: Publish BotKube image
+
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
+    branches:
+      - "develop"
+
+env:
+  GO_VERSION: 1.18
+
+jobs:
+
+  save-image:
+    name: Build and save BotKube image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
+          version: latest
+
+      - name: Save
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          make save-pr-image
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.APP }}-${{github.sha}}
+          path: /tmp/
+          retention-days: 1
+
+  push-image:
+    name: Push BotKube image
+    runs-on: ubuntu-latest
+    needs: [save-image]
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.APP }}-${{github.sha}}
+          path: /tmp
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: make push-pr-image
+
+      - name: Delete Docker image artifact
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: ${{ matrix.APP }}-${{github.sha}}
+
+      - name: Summary
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          cat > $GITHUB_STEP_SUMMARY << ENDOFFILE
+
+          ### BotKube image published successfully! :rocket:
+          To test BotKube with PR changes, run:
+
+              gh pr checkout ${PR_NUMBER}
+              helm install botkube -n botkube --create-namespace \\
+              --set image.repository=infracloudio/pr/botkube \\
+              --set image.tag=v${PR_NUMBER} \\
+              ./helm/botkube
+
+          ENDOFFILE

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -115,7 +115,7 @@ jobs:
               gh pr checkout ${PR_NUMBER}
               helm install botkube -n botkube --create-namespace \\
               --set image.repository=infracloudio/pr/botkube \\
-              --set image.tag=PR-${PR_NUMBER} \\
+              --set image.tag=v${PR_NUMBER}-PR \\
               ./helm/botkube
 
           ENDOFFILE

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -27,6 +27,7 @@ on:
 
 env:
   GO_VERSION: 1.18
+  PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
 
@@ -57,15 +58,13 @@ jobs:
           version: latest
 
       - name: Save
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           make save-pr-image
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.APP }}-${{github.sha}}
+          name: botkube-${{github.sha}}
           path: /tmp/*.tar
           retention-days: 1
 
@@ -80,14 +79,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.APP }}-${{github.sha}}
+          name: botkube-${{github.sha}}
           path: /tmp
 
       - name: Login to GitHub Container Registry
@@ -98,19 +97,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: make push-pr-image
 
       - name: Delete Docker image artifact
         uses: geekyeggo/delete-artifact@v1
         if: always()
         with:
-          name: ${{ matrix.APP }}-${{github.sha}}
+          name: botkube-${{github.sha}}
 
       - name: Summary
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           cat > $GITHUB_STEP_SUMMARY << ENDOFFILE
 

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -115,7 +115,7 @@ jobs:
               gh pr checkout ${PR_NUMBER}
               helm install botkube -n botkube --create-namespace \\
               --set image.repository=infracloudio/pr/botkube \\
-              --set image.tag=v${PR_NUMBER}-PR \\
+              --set image.tag=${PR_NUMBER}-PR \\
               ./helm/botkube
 
           ENDOFFILE

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -115,7 +115,7 @@ jobs:
               gh pr checkout ${PR_NUMBER}
               helm install botkube -n botkube --create-namespace \\
               --set image.repository=infracloudio/pr/botkube \\
-              --set image.tag=v${PR_NUMBER} \\
+              --set image.tag=PR-${PR_NUMBER} \\
               ./helm/botkube
 
           ENDOFFILE

--- a/.github/workflows/pr-image.yaml
+++ b/.github/workflows/pr-image.yaml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Delete Docker image artifact
         uses: geekyeggo/delete-artifact@v1
+        if: always()
         with:
           name: ${{ matrix.APP }}-${{github.sha}}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,14 +27,14 @@ changelog:
   skip: true
 dockers:
   - image_templates:
-      - "ghcr.io/mszostok/botkube:{{ .Tag }}-amd64"
+      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-amd64"
     use: buildx
     dockerfile: "build/Dockerfile"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=botkube_version={{ .Tag }}"
   - image_templates:
-      - "ghcr.io/mszostok/botkube:{{ .Tag }}-arm64"
+      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-arm64"
     use: buildx
     goarch: arm64
     dockerfile: "build/Dockerfile"
@@ -42,7 +42,7 @@ dockers:
       - "--platform=linux/arm64"
       - "--build-arg=botkube_version={{ .Tag }}"
   - image_templates:
-      - "ghcr.io/mszostok/botkube:{{ .Tag }}-armv7"
+      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-armv7"
     use: buildx
     goarch: arm
     goarm: 7
@@ -52,8 +52,8 @@ dockers:
       - "--build-arg=botkube_version={{ .Tag }}"
 
 docker_manifests:
-  - name_template: ghcr.io/mszostok/botkube:{{ .Tag }}
+  - name_template: ghcr.io/infracloudio/botkube:{{ .Tag }}
     image_templates:
-      - ghcr.io/mszostok/botkube:{{ .Tag }}-amd64
-      - ghcr.io/mszostok/botkube:{{ .Tag }}-arm64
-      - ghcr.io/mszostok/botkube:{{ .Tag }}-armv7
+      - ghcr.io/infracloudio/botkube:{{ .Tag }}-amd64
+      - ghcr.io/infracloudio/botkube:{{ .Tag }}-arm64
+      - ghcr.io/infracloudio/botkube:{{ .Tag }}-armv7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,14 +27,14 @@ changelog:
   skip: true
 dockers:
   - image_templates:
-      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-amd64"
+      - "ghcr.io/mszostok/botkube:{{ .Tag }}-amd64"
     use: buildx
     dockerfile: "build/Dockerfile"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=botkube_version={{ .Tag }}"
   - image_templates:
-      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-arm64"
+      - "ghcr.io/mszostok/botkube:{{ .Tag }}-arm64"
     use: buildx
     goarch: arm64
     dockerfile: "build/Dockerfile"
@@ -42,7 +42,7 @@ dockers:
       - "--platform=linux/arm64"
       - "--build-arg=botkube_version={{ .Tag }}"
   - image_templates:
-      - "ghcr.io/infracloudio/botkube:{{ .Tag }}-armv7"
+      - "ghcr.io/mszostok/botkube:{{ .Tag }}-armv7"
     use: buildx
     goarch: arm
     goarm: 7
@@ -52,8 +52,8 @@ dockers:
       - "--build-arg=botkube_version={{ .Tag }}"
 
 docker_manifests:
-  - name_template: ghcr.io/infracloudio/botkube:{{ .Tag }}
+  - name_template: ghcr.io/mszostok/botkube:{{ .Tag }}
     image_templates:
-      - ghcr.io/infracloudio/botkube:{{ .Tag }}-amd64
-      - ghcr.io/infracloudio/botkube:{{ .Tag }}-arm64
-      - ghcr.io/infracloudio/botkube:{{ .Tag }}-armv7
+      - ghcr.io/mszostok/botkube:{{ .Tag }}-amd64
+      - ghcr.io/mszostok/botkube:{{ .Tag }}-arm64
+      - ghcr.io/mszostok/botkube:{{ .Tag }}-armv7

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,14 @@ gorelease:
 release-snapshot:
 	@./hack/goreleaser.sh release_snapshot
 
+# Build project and save PR images with PR_NUMBER tag
+save-pr-image:
+	@./hack/goreleaser.sh save_pr_image
+
+# Load project and push PR images with PR_NUMBER tag
+push-pr-image:
+	@./hack/goreleaser.sh push_pr_image
+
 # system checks
 system-check:
 	@echo "Checking system information"

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -55,7 +55,7 @@ save_pr_image() {
     exit 1
   fi
 
-  export GORELEASER_CURRENT_TAG=v${PR_NUMBER}-PR
+  export GORELEASER_CURRENT_TAG=${PR_NUMBER}-PR
   goreleaser release --rm-dist --snapshot --skip-publish
 
   # Re-tag with 'pr' prefix
@@ -77,7 +77,7 @@ push_pr_image() {
     exit 1
   fi
 
-  export GORELEASER_CURRENT_TAG=v${PR_NUMBER}-PR
+  export GORELEASER_CURRENT_TAG=${PR_NUMBER}-PR
 
   # Load images
   docker load --input /tmp/${IMAGE_NAME}-amd64.tar

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -77,9 +77,15 @@ push_pr_image() {
   export GORELEASER_CURRENT_TAG=v${PR_NUMBER}
 
   # Load images
+
+  docker images
+
   docker load --input /tmp/botkube-amd64.tar
   docker load --input /tmp/botkube-arm64.tar
   docker load --input /tmp/botkube-armv7.tar
+
+  docker images
+
   # Create manifest
   docker manifest create ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG} \
     --amend ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64 \

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -77,14 +77,14 @@ push_pr_image() {
   export GORELEASER_CURRENT_TAG=v${PR_NUMBER}
 
   # Load images
-
-  docker images
-
   docker load --input /tmp/botkube-amd64.tar
   docker load --input /tmp/botkube-arm64.tar
   docker load --input /tmp/botkube-armv7.tar
 
-  docker images
+	# Push images
+	docker push ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64
+	docker push ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64
+	docker push ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7
 
   # Create manifest
   docker manifest create ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG} \

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -55,7 +55,7 @@ save_pr_image() {
     exit 1
   fi
 
-  export GORELEASER_CURRENT_TAG=PR-${PR_NUMBER}
+  export GORELEASER_CURRENT_TAG=v${PR_NUMBER}-PR
   goreleaser release --rm-dist --snapshot --skip-publish
 
   # Re-tag with 'pr' prefix
@@ -77,7 +77,7 @@ push_pr_image() {
     exit 1
   fi
 
-  export GORELEASER_CURRENT_TAG=PR-${PR_NUMBER}
+  export GORELEASER_CURRENT_TAG=v${PR_NUMBER}-PR
 
   # Load images
   docker load --input /tmp/${IMAGE_NAME}-amd64.tar

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -56,14 +56,14 @@ save_pr_image() {
   goreleaser release --rm-dist --snapshot --skip-publish
 
   # Re-tag with 'pr' prefix
-  docker tag ghcr.io/mszostok/botkube:${GORELEASER_CURRENT_TAG}-amd64 ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64
-  docker tag ghcr.io/mszostok/botkube:${GORELEASER_CURRENT_TAG}-arm64 ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64
-  docker tag ghcr.io/mszostok/botkube:${GORELEASER_CURRENT_TAG}-armv7 ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7
+  docker tag ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-amd64 ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64
+  docker tag ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-arm64 ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64
+  docker tag ghcr.io/infracloudio/botkube:${GORELEASER_CURRENT_TAG}-armv7 ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7
 
   # Push images
-  docker save ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64 > /tmp/botkube-amd64.tar
-  docker save ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64 > /tmp/botkube-arm64.tar
-  docker save ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7 > /tmp/botkube-armv7.tar
+  docker save ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64 > /tmp/botkube-amd64.tar
+  docker save ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64 > /tmp/botkube-arm64.tar
+  docker save ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7 > /tmp/botkube-armv7.tar
 }
 
 push_pr_image() {
@@ -82,16 +82,16 @@ push_pr_image() {
   docker load --input /tmp/botkube-armv7.tar
 
 	# Push images
-	docker push ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64
-	docker push ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64
-	docker push ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7
+	docker push ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64
+	docker push ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64
+	docker push ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7
 
   # Create manifest
-  docker manifest create ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG} \
-    --amend ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64 \
-    --amend ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64 \
-    --amend ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7
-  docker manifest push ghcr.io/mszostok/pr/botkube:${GORELEASER_CURRENT_TAG}
+  docker manifest create ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG} \
+    --amend ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-amd64 \
+    --amend ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-arm64 \
+    --amend ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}-armv7
+  docker manifest push ghcr.io/infracloudio/pr/botkube:${GORELEASER_CURRENT_TAG}
 }
 
 build() {

--- a/hack/goreleaser.sh
+++ b/hack/goreleaser.sh
@@ -55,7 +55,7 @@ save_pr_image() {
     exit 1
   fi
 
-  export GORELEASER_CURRENT_TAG=PR-v${PR_NUMBER}
+  export GORELEASER_CURRENT_TAG=PR-${PR_NUMBER}
   goreleaser release --rm-dist --snapshot --skip-publish
 
   # Re-tag with 'pr' prefix
@@ -77,7 +77,7 @@ push_pr_image() {
     exit 1
   fi
 
-  export GORELEASER_CURRENT_TAG=PR-v${PR_NUMBER}
+  export GORELEASER_CURRENT_TAG=PR-${PR_NUMBER}
 
   # Load images
   docker load --input /tmp/${IMAGE_NAME}-amd64.tar


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY

Add an option to push the BotKube image automatically on PR. It's alternative approach for https://github.com/infracloudio/botkube/pull/604.

This PR will solve the problem with manual PR builds, e.g. we had that issue here:
- https://github.com/infracloudio/botkube/pull/601
- https://github.com/infracloudio/botkube/pull/593
- https://github.com/infracloudio/botkube/pull/582
- https://github.com/infracloudio/botkube/pull/583

Example run: https://github.com/mszostok/botkube/runs/6714112689?check_suite_focus=true

Fixes #590 

To ensure that secrets won't be available for untrusted code, first we need to build the image and share it with the second job, which doesn't check out the untrusted code and can safely push an artifact to ghcr.io.

The flow is as follows:
```
Job1: image build -> image save -> artifact upload 
Job2: artifact download -> image load -> image push
```
Job1—runs untrusted code but without write repo perms
Job2—push built image with package write perms

#### Security

This article describes it well: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/