### PR TITLE
Fix ServiceMonitor selector

### DIFF
--- a/helm/botkube/templates/servicemonitor.yaml
+++ b/helm/botkube/templates/servicemonitor.yaml
@@ -23,7 +23,6 @@ spec:
       helm.sh/chart: {{ include "botkube.chart" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/managed-by: {{ .Release.Service }}
-      component: controller
       app: botkube
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug fix Pull Request

##### SUMMARY

- Fix ServiceMonitor selector

Fixes #431 

##### TESTING

Install Prometheus stack with BotKube.

```bash
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm install monitoring prometheus-community/kube-prometheus-stack

cat > /tmp/values.yaml << ENDOFFILE
config:
  settings:
    clustername: sample
    kubectl:
      enabled: true
serviceMonitor:
  enabled: true
  labels:
    release: monitoring
ENDOFFILE

helm install botkube ./helm/botkube -f /tmp/values.yaml --wait

kubectl port-forward svc/monitoring-kube-prometheus-prometheus 9090:9090
```

See targets on http://localhost:9090/targets page. BotKube target will be up after a while.