### PR TITLE
Implement E2E tests against BotKube deployed on K8s and real Slack API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,8 @@ issues:
     - (G104|G307)
 run:
   tests: true
+  build-tags:
+    - integration
   skip-files:
     - ".*\\.generated\\.go$"
 linters:

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/infracloudio/botkube
 
 require (
+	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd
 	github.com/aws/aws-sdk-go v1.44.20
 	github.com/bwmarrin/discordgo v0.25.0
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/google/go-github/v44 v44.1.0
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/infracloudio/msbotbuilder-go v0.2.5
@@ -30,7 +32,6 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -62,7 +63,6 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -121,7 +121,6 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
-	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d // indirect
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/go.mod
+++ b/go.mod
@@ -121,6 +121,7 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
+	golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d // indirect
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/go.sum
+++ b/go.sum
@@ -1263,8 +1263,6 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925/go.mod h1:1phAWC201xIgDyaFpmDeZkgf70Q4Pd/CNqfRtVPtxNw=
-golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d h1:vtUKgx8dahOomfFzLREU8nSv25YHnTgLBn4rDnWZdU0=
-golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/go.sum
+++ b/go.sum
@@ -1263,6 +1263,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925/go.mod h1:1phAWC201xIgDyaFpmDeZkgf70Q4Pd/CNqfRtVPtxNw=
+golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d h1:vtUKgx8dahOomfFzLREU8nSv25YHnTgLBn4rDnWZdU0=
+golang.org/x/exp v0.0.0-20220613132600-b0d781184e0d/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/helm/botkube/values.yaml
+++ b/helm/botkube/values.yaml
@@ -284,7 +284,7 @@ config:
         # method which are allowed
         verbs: ["api-resources", "api-versions", "cluster-info", "describe", "diff", "explain", "get", "logs", "top", "auth"]
         # resource configuration which is allowed
-        resources: ["deployments", "pods" , "namespaces", "daemonsets", "statefulsets", "storageclasses", "nodes" ]
+        resources: ["deployments", "pods" , "namespaces", "daemonsets", "statefulsets", "storageclasses", "nodes", "configmaps"]
       # set Namespace to execute BotKube kubectl commands by default
       defaultNamespace: default
       # Set true to enable commands execution from configured channel only

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -374,8 +374,8 @@ func (e *DefaultExecutor) runInfoCommand(args []string, isAuthChannel bool) stri
 		return fmt.Sprintf(WrongClusterCmdMsg, args[3])
 	}
 
-	allowedVerbs := e.getSortedCommandsStr("allowed verbs:", e.resMapping.AllowedKubectlVerbMap)
-	allowedResources := e.getSortedCommandsStr("allowed resources:", e.resMapping.AllowedKubectlResourceMap)
+	allowedVerbs := e.getSortedEnabledCommands("allowed verbs", e.resMapping.AllowedKubectlVerbMap)
+	allowedResources := e.getSortedEnabledCommands("allowed resources", e.resMapping.AllowedKubectlResourceMap)
 	return fmt.Sprintf("%s%s", allowedVerbs, allowedResources)
 }
 
@@ -455,22 +455,22 @@ func (e *DefaultExecutor) showControllerConfig() (string, error) {
 	return string(b), nil
 }
 
-func (e *DefaultExecutor) getSortedCommandsStr(header string, commands map[string]bool) string {
-	strBldr := new(strings.Builder)
-	strBldr.WriteString(fmt.Sprintf("%s\n", header))
-
+func (e *DefaultExecutor) getSortedEnabledCommands(header string, commands map[string]bool) string {
 	var keys []string
 	for key := range commands {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
 		if !commands[key] {
 			continue
 		}
 
-		strBldr.WriteString(fmt.Sprintf("  - %s\n", key))
+		keys = append(keys, key)
 	}
-	return strBldr.String()
+	sort.Strings(keys)
+
+	if len(keys) == 0 {
+		return fmt.Sprintf("%s: []", header)
+	}
+
+	const itemSeparator = "\n  - "
+	items := strings.Join(keys, itemSeparator)
+	return fmt.Sprintf("%s:%s%s\n", header, itemSeparator, items)
 }

--- a/pkg/execute/executor.go
+++ b/pkg/execute/executor.go
@@ -22,6 +22,7 @@ package execute
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"unicode"
@@ -373,9 +374,9 @@ func (e *DefaultExecutor) runInfoCommand(args []string, isAuthChannel bool) stri
 		return fmt.Sprintf(WrongClusterCmdMsg, args[3])
 	}
 
-	allowedVerbs := utils.GetStringInYamlFormat("allowed verbs:", e.resMapping.AllowedKubectlVerbMap)
-	allowedResources := utils.GetStringInYamlFormat("allowed resources:", e.resMapping.AllowedKubectlResourceMap)
-	return allowedVerbs + allowedResources
+	allowedVerbs := e.getSortedCommandsStr("allowed verbs:", e.resMapping.AllowedKubectlVerbMap)
+	allowedResources := e.getSortedCommandsStr("allowed resources:", e.resMapping.AllowedKubectlResourceMap)
+	return fmt.Sprintf("%s%s", allowedVerbs, allowedResources)
 }
 
 // Use tabwriter to display string in tabular form
@@ -385,8 +386,8 @@ func (e *DefaultExecutor) makeFiltersList() string {
 	w := tabwriter.NewWriter(buf, 5, 0, 1, ' ', 0)
 
 	fmt.Fprintln(w, "FILTER\tENABLED\tDESCRIPTION")
-	for k, v := range e.filterEngine.ShowFilters() {
-		fmt.Fprintf(w, "%s\t%v\t%s\n", k.Name(), v, k.Describe())
+	for _, filter := range e.filterEngine.RegisteredFilters() {
+		fmt.Fprintf(w, "%s\t%v\t%s\n", filter.Name(), filter.Enabled, filter.Describe())
 	}
 
 	w.Flush()
@@ -452,4 +453,24 @@ func (e *DefaultExecutor) showControllerConfig() (string, error) {
 	}
 
 	return string(b), nil
+}
+
+func (e *DefaultExecutor) getSortedCommandsStr(header string, commands map[string]bool) string {
+	strBldr := new(strings.Builder)
+	strBldr.WriteString(fmt.Sprintf("%s\n", header))
+
+	var keys []string
+	for key := range commands {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if !commands[key] {
+			continue
+		}
+
+		strBldr.WriteString(fmt.Sprintf("  - %s\n", key))
+	}
+	return strBldr.String()
 }

--- a/pkg/execute/executor_test.go
+++ b/pkg/execute/executor_test.go
@@ -1,0 +1,54 @@
+package execute
+
+import (
+	"testing"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultExecutor_getSortedEnabledCommands(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		InputHeader    string
+		InputMap       map[string]bool
+		ExpectedOutput string
+	}{
+		{
+			Name:        "All commands disabled",
+			InputHeader: "test",
+			InputMap: map[string]bool{
+				"cmd1": false,
+				"cmd2": false,
+			},
+			ExpectedOutput: "test: []",
+		},
+		{
+			Name:        "All commands enabled",
+			InputHeader: "foo",
+			InputMap: map[string]bool{
+				"b1": true,
+				"a2": false,
+				"a3": true,
+				"a4": true,
+				"a5": true,
+				"a6": false,
+			},
+			ExpectedOutput: heredoc.Doc(`
+				foo:
+				  - a3
+				  - a4
+				  - a5
+				  - b1
+			`),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			e := &DefaultExecutor{}
+			res := e.getSortedEnabledCommands(testCase.InputHeader, testCase.InputMap)
+
+			assert.Equal(t, testCase.ExpectedOutput, res)
+		})
+	}
+}

--- a/pkg/filterengine/filterengine.go
+++ b/pkg/filterengine/filterengine.go
@@ -38,6 +38,7 @@ type DefaultFilterEngine struct {
 
 // FilterEngine has methods to register and run filters
 type FilterEngine interface {
+	// TODO: Why `Run` method takes object as input argument, if event already contains it as well? Refactor it if possible
 	Run(context.Context, interface{}, events.Event) events.Event
 	Register(...Filter)
 	RegisteredFilters() []RegisteredFilter

--- a/pkg/filterengine/filterengine.go
+++ b/pkg/filterengine/filterengine.go
@@ -22,6 +22,7 @@ package filterengine
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/sirupsen/logrus"
 
@@ -32,16 +33,21 @@ import (
 type DefaultFilterEngine struct {
 	log logrus.FieldLogger
 
-	// TODO: Change map key to filter name to be able to SetFilter without iterating through the whole map
-	FiltersMap map[Filter]bool
+	filters map[string]RegisteredFilter
 }
 
 // FilterEngine has methods to register and run filters
 type FilterEngine interface {
 	Run(context.Context, interface{}, events.Event) events.Event
 	Register(...Filter)
-	ShowFilters() map[Filter]bool
+	RegisteredFilters() []RegisteredFilter
 	SetFilter(string, bool) error
+}
+
+// RegisteredFilter contains details about registered filter
+type RegisteredFilter struct {
+	Enabled bool
+	Filter
 }
 
 // Filter has method to run filter
@@ -54,16 +60,17 @@ type Filter interface {
 // New creates new DefaultFilterEngine object
 func New(log logrus.FieldLogger) *DefaultFilterEngine {
 	return &DefaultFilterEngine{
-		log:        log,
-		FiltersMap: make(map[Filter]bool),
+		log:     log,
+		filters: make(map[string]RegisteredFilter),
 	}
 }
 
-// Run runs the registered filters
+// Run runs the registered filters always iterating over a slice of filters with sorted keys
 func (f *DefaultFilterEngine) Run(ctx context.Context, object interface{}, event events.Event) events.Event {
 	f.log.Debug("Running registered filters")
-	for filter, enabled := range f.FiltersMap {
-		if !enabled {
+	filters := f.RegisteredFilters()
+	for _, filter := range filters {
+		if !filter.Enabled {
 			continue
 		}
 
@@ -79,24 +86,38 @@ func (f *DefaultFilterEngine) Run(ctx context.Context, object interface{}, event
 func (f *DefaultFilterEngine) Register(filters ...Filter) {
 	for _, filter := range filters {
 		f.log.Infof("Registering filter %q", filter.Name())
-		f.FiltersMap[filter] = true
+		f.filters[filter.Name()] = RegisteredFilter{
+			Filter:  filter,
+			Enabled: true,
+		}
 	}
 }
 
-// ShowFilters return map of filter name and status
-// TODO: This method is used for printing filters, but the order of the list is not preserved. Fix it.
-func (f DefaultFilterEngine) ShowFilters() map[Filter]bool {
-	return f.FiltersMap
+// RegisteredFilters returns sorted slice of registered filters
+func (f DefaultFilterEngine) RegisteredFilters() []RegisteredFilter {
+	var keys []string
+	for key := range f.filters {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var registeredFilters []RegisteredFilter
+	for _, key := range keys {
+		registeredFilters = append(registeredFilters, f.filters[key])
+	}
+
+	return registeredFilters
 }
 
 // SetFilter sets filter value in FilterMap to enable or disable filter
 func (f *DefaultFilterEngine) SetFilter(name string, flag bool) error {
 	// Find filter struct name
-	for k := range f.FiltersMap {
-		if k.Name() == name {
-			f.FiltersMap[k] = flag
-			return nil
-		}
+	filter, ok := f.filters[name]
+	if !ok {
+		return fmt.Errorf("couldn't find filter with name %q", name)
 	}
-	return fmt.Errorf("couldn't find filter with name %q", name)
+
+	filter.Enabled = flag
+	f.filters[name] = filter
+	return nil
 }

--- a/pkg/filterengine/filters/ingress_validator.go
+++ b/pkg/filterengine/filters/ingress_validator.go
@@ -82,7 +82,7 @@ func (f *IngressValidator) Run(ctx context.Context, object interface{}, event *e
 	for _, tls := range ingressObj.Spec.TLS {
 		_, err := ValidSecret(ctx, f.dynamicCli, tls.SecretName, ingNs)
 		if err != nil {
-			event.Recommendations = append(event.Recommendations, fmt.Sprintf("TLS secret %s does not exist", tls.SecretName))
+			event.Warnings = append(event.Warnings, fmt.Sprintf("TLS secret '%s' does not exist", tls.SecretName))
 		}
 	}
 	f.log.Debug("Ingress Validator filter successful!")

--- a/pkg/filterengine/filters/ingress_validator_test.go
+++ b/pkg/filterengine/filters/ingress_validator_test.go
@@ -1,0 +1,83 @@
+package filters
+
+import (
+	"context"
+	"testing"
+
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+
+	"github.com/infracloudio/botkube/pkg/config"
+	"github.com/infracloudio/botkube/pkg/events"
+)
+
+func TestIngressValidator_Run_HappyPath(t *testing.T) {
+	// given
+	dynamicCli := fake.NewSimpleDynamicClient(runtime.NewScheme())
+	logger, _ := logtest.NewNullLogger()
+	ingressValidator := NewIngressValidator(logger, dynamicCli)
+
+	ingress := fixIngress()
+	unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&ingress)
+	require.NoError(t, err)
+	unstr := &unstructured.Unstructured{Object: unstrObj}
+
+	event, err := events.New(ingress.ObjectMeta, unstr, config.CreateEvent, "networking.k8s.io/v1/ingresses", "sample")
+	require.NoError(t, err)
+
+	// when
+	err = ingressValidator.Run(context.Background(), unstr, &event)
+
+	// then
+	assert.NoError(t, err)
+
+	require.Len(t, event.Warnings, 2)
+	assert.Contains(t, event.Warnings, "Service 'test-service' used in ingress 'ingress-with-service' config does not exist or port '80' not exposed")
+	assert.Contains(t, event.Warnings, "TLS secret 'not-existing' does not exist")
+}
+
+func fixIngress() *networkingv1.Ingress {
+	return &networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ingress-with-service",
+		},
+		Spec: networkingv1.IngressSpec{
+			TLS: []networkingv1.IngressTLS{
+				{Hosts: []string{"foo"}, SecretName: "not-existing"},
+			},
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "foo",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path: "testpath",
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: "test-service",
+											Port: networkingv1.ServiceBackendPort{
+												Number: int32(80),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,7 +20,6 @@
 package utils
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"regexp"
@@ -156,18 +155,6 @@ func GVRToString(gvr schema.GroupVersionResource) string {
 // TransformIntoTypedObject uses unstructured interface and creates a typed object
 func TransformIntoTypedObject(obj *unstructured.Unstructured, typedObject interface{}) error {
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), typedObject)
-}
-
-//GetStringInYamlFormat get the formatted commands list
-func GetStringInYamlFormat(header string, commands map[string]bool) string {
-	var b bytes.Buffer
-	fmt.Fprintln(&b, header)
-	for k, v := range commands {
-		if v {
-			fmt.Fprintf(&b, "  - %s\n", k)
-		}
-	}
-	return b.String()
 }
 
 // Contains tells whether a contains x.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -20,7 +20,6 @@
 package utils
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -47,18 +46,6 @@ func TestGetClusterNameFromKubectlCmd(t *testing.T) {
 		if got != ts.expected {
 			t.Errorf("expected: %v, got: %v", ts.expected, got)
 		}
-	}
-}
-
-func TestGetStringInYamlFormat(t *testing.T) {
-	var header = "allowed verbs"
-	var commands = map[string]bool{
-		"api-versions": true,
-	}
-	expected := fmt.Sprintf(header + "\n  - api-versions\n")
-	got := GetStringInYamlFormat(header, commands)
-	if got != expected {
-		t.Errorf("expected: %v, got: %v", expected, got)
 	}
 }
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,35 @@
+# syntax = docker/dockerfile:1-experimental
+
+FROM golang:1.18-alpine as builder
+
+ARG TEST_NAME
+ARG SOURCE_PATH="./tests/$TEST_NAME"
+
+WORKDIR /botkube
+
+# Use experimental frontend syntax to cache dependencies.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Use experimental frontend syntax to cache go build.
+# Replace `COPY . .` with `--mount=target=.` to speed up as we do not need them to persist in the final image.
+# https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md
+RUN --mount=target=. \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOARCH=amd64 go test -c -tags=integration -o /bin/$TEST_NAME $SOURCE_PATH
+
+FROM scratch as generic
+
+ARG TEST_NAME
+
+# Copy common CA certificates from Builder image (installed by default with ca-certificates package)
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+COPY --from=builder /bin/$TEST_NAME /test
+
+LABEL name="botkube" \
+    test=$TEST_NAME
+
+CMD ["/test", "-test.v"]

--- a/test/doc.go
+++ b/test/doc.go
@@ -1,0 +1,6 @@
+// Package test contains integration tests with fake Slack and Kubernetes APIs.
+//
+// Deprecated: This package is deprecated in favor of `../tests` package
+// which contains real integration tests against real Slack and BotKube installation.
+// Eventually, the fake E2E tests will be converted in unit tests and removed completely.
+package test

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,8 @@ This directory contains E2E tests which are run against BotKube installed on Kub
 
 ### Configure Tester Slack application
 
+> **NOTE:** This is something you need to do only once. Once the tester app is configured, you can use its token for running integration tests as many times as you want.
+
 1. Create new Slack Application on [this page](https://api.slack.com/apps)
 2. Use "From an app manifest" option
 3. Copy and paste this manifest:
@@ -38,6 +40,12 @@ This directory contains E2E tests which are run against BotKube installed on Kub
 4. Install this app into your workspace
 5. Navigate to the **OAuth & Permissions** section
 6. Copy the **Bot User OAuth Token** and save it for later.
+
+  You can already export it as environment variable for [running the tests locally](#run-tests-locally):
+
+  ```bash
+  export SLACK_TESTER_APP_TOKEN="{BotKube tester app token}
+  ```
 
 ## Run tests locally
 
@@ -78,19 +86,17 @@ To run the tests manually against the latest development version, follow these s
     extraAnnotations:
       botkube.io/disable: "true"
     image:
-      registry: docker.io
-      repository: pkosiec/botkube 
-      tag: e2e-tests
+      tag: v9.99.9-dev
     ENDOFFILE
     
     helm install botkube --namespace botkube ./helm/botkube -f /tmp/values.yaml --wait
     ```
 
 
-1. Export required environment variables
+1. Export required environment variables:
 
     ```bash
-    export SLACK_TESTER_APP_TOKEN="{BotKube tester app token}" # WARNING: This is a token for Tester, not the BotKube Slack bot!
+    export SLACK_TESTER_APP_TOKEN="{BotKube tester app token}" # WARNING: This is a token for Tester, not the BotKube Slack bot.
     export KUBECONFIG=/Users/$USER/.kube/config # set custom path if necessary
     ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,93 @@
+# E2E Tests
+
+This directory contains E2E tests which are run against BotKube installed on Kubernetes cluster and Slack API.
+
+## Prerequisites
+
+- Kubernetes cluster (e.g. local one created with `k3d`)
+- BotKube bot app configured for a given Slack workspace according to the [instruction](https://www.botkube.io/installation/slack/)
+- BotKube tester app configured according to the [instruction](#configure-tester-slack-application)
+
+### Configure Tester Slack application
+
+1. Create new Slack Application on [this page](https://api.slack.com/apps)
+2. Use "From an app manifest" option
+3. Copy and paste this manifest:
+
+    ```yaml
+    display_information:
+      name: BotKube tester
+    features:
+      bot_user:
+        display_name: Tester
+        always_online: false
+    oauth_config:
+      scopes:
+        bot:
+          - channels:join
+          - channels:manage
+          - chat:write
+          - users:read
+          - channels:history
+    settings:
+      org_deploy_enabled: false
+      socket_mode_enabled: false
+      token_rotation_enabled: false
+    ```
+
+4. Install this app into your workspace
+5. Navigate to the **OAuth & Permissions** section
+6. Copy the **Bot User OAuth Token** and save it for later.
+
+## Run tests locally
+
+To run the tests manually against the latest development version, follow these steps:
+
+1. Install BotKube using Helm chart:
+        
+    ```bash
+    export SLACK_BOT_TOKEN="{token for your configured BotKube app}" # WARNING: It is token for BotKube Slack bot, not the Tester!
+    cat > /tmp/values.yaml << ENDOFFILE
+    communications:
+      slack:
+        enabled: false # Tests will override this temporarily
+        token: ${SLACK_BOT_TOKEN} # Provide a valid token for BotKube app
+        channel: botkube-test # Tests will override this temporarily
+    config:
+      resources:
+        - name: v1/configmaps
+          namespaces:
+            include:
+              - botkube
+          events:
+            - create
+            - update
+            - delete
+      settings:
+        clustername: sample
+        kubectl:
+          enabled: true
+        upgradeNotifier: false
+      enabled: true
+    image:
+      registry: docker.io
+      repository: pkosiec/botkube 
+      tag: e2e-tests
+    ENDOFFILE
+    
+    helm install botkube --namespace botkube ./helm/botkube -f /tmp/values.yaml --wait
+    ```
+
+
+1. Export required environment variables
+
+    ```bash
+    export SLACK_TESTER_APP_TOKEN="{BotKube tester app token}" # WARNING: This is a token for Tester, not the BotKube Slack bot!
+    export KUBECONFIG=/Users/$USER/.kube/config # set custom path if necessary
+    ```
+
+1. Run the tests and wait for the result:
+
+    ```bash
+    make test-integration
+    ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,12 +63,20 @@ To run the tests manually against the latest development version, follow these s
             - create
             - update
             - delete
-      settings:
+        - name: v1/pods
+          namespaces:
+            include:
+              - botkube
+          events:
+            - create
+      settings: 
         clustername: sample
         kubectl:
           enabled: true
         upgradeNotifier: false
       enabled: true
+    extraAnnotations:
+      botkube.io/disable: "true"
     image:
       registry: docker.io
       repository: pkosiec/botkube 

--- a/tests/e2e/k8s_helpers_test.go
+++ b/tests/e2e/k8s_helpers_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	appsv1cli "k8s.io/client-go/kubernetes/typed/apps/v1"
+	deploymentutil "k8s.io/kubectl/pkg/util/deployment"
+)
+
+func setTestEnvsForDeploy(t *testing.T, appCfg Config, deployNsCli appsv1cli.DeploymentInterface, channelName string) func(t *testing.T) {
+	t.Helper()
+
+	slackEnabledEnvName := appCfg.Deployment.Envs.SlackEnabledName
+	slackChannelIDEnvName := appCfg.Deployment.Envs.SlackChannelIDName
+
+	deployment, err := deployNsCli.Get(context.Background(), appCfg.Deployment.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, deployment)
+
+	containerIdx, exists := findContainerIdxByName(deployment, appCfg.Deployment.ContainerName)
+	require.True(t, exists)
+
+	envs := deployment.Spec.Template.Spec.Containers[containerIdx].Env
+
+	var originalEnvs []v1.EnvVar
+	channelIDEnv, exists := findEnv(envs, slackChannelIDEnvName)
+	if exists {
+		originalEnvs = append(originalEnvs, channelIDEnv)
+	}
+	enabledEnv, exists := findEnv(envs, slackEnabledEnvName)
+	if exists {
+		originalEnvs = append(originalEnvs, enabledEnv)
+	}
+
+	restoreDeployEnvsFn := func(t *testing.T) {
+		t.Helper()
+		t.Logf("Restoring envs for deployment...")
+		deployment, err := deployNsCli.Get(context.Background(), appCfg.Deployment.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, deployment)
+
+		containerIdx, exists := findContainerIdxByName(deployment, appCfg.Deployment.ContainerName)
+		require.True(t, exists)
+
+		deployment.Spec.Template.Spec.Containers[containerIdx].Env = updateEnv(envs,
+			nil,
+			[]string{slackEnabledEnvName, slackChannelIDEnvName},
+		)
+
+		if len(originalEnvs) > 0 {
+			deployment.Spec.Template.Spec.Containers[containerIdx].Env = updateEnv(envs, originalEnvs, nil)
+		}
+		_, err = deployNsCli.Update(context.Background(), deployment, metav1.UpdateOptions{})
+		require.NoError(t, err)
+	}
+
+	deployment.Spec.Template.Spec.Containers[containerIdx].Env = updateEnv(
+		envs,
+		[]v1.EnvVar{
+			{Name: slackEnabledEnvName, Value: strconv.FormatBool(true)},
+			{Name: slackChannelIDEnvName, Value: channelName},
+		},
+		nil,
+	)
+
+	_, err = deployNsCli.Update(context.Background(), deployment, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	return restoreDeployEnvsFn
+}
+
+func waitForDeploymentReady(deployNsCli appsv1cli.DeploymentInterface, deploymentName string, waitTimeout time.Duration) error {
+	// Wait for deployment ready
+	var lastErr error
+	err := wait.Poll(pollInterval, waitTimeout, func() (done bool, err error) {
+		deployment, err := deployNsCli.Get(context.Background(), deploymentName, metav1.GetOptions{})
+		if err != nil {
+			lastErr = err
+			return false, nil
+		}
+
+		condition := deploymentutil.GetDeploymentCondition(deployment.Status, appsv1.DeploymentAvailable)
+		if condition == nil {
+			lastErr = fmt.Errorf("deployment condition %q is nil", appsv1.DeploymentAvailable)
+			return false, nil
+		}
+
+		return condition.Status == v1.ConditionTrue, nil
+	})
+	if err != nil {
+		if err == wait.ErrWaitTimeout {
+			return lastErr
+		}
+		return err
+	}
+
+	return nil
+}
+
+func findContainerIdxByName(deployment *appsv1.Deployment, containerName string) (int, bool) {
+	containerIdx := -1
+
+	if deployment == nil {
+		return containerIdx, false
+	}
+
+	containers := deployment.Spec.Template.Spec.Containers
+	for i, container := range containers {
+		if container.Name != containerName {
+			continue
+		}
+
+		containerIdx = i
+	}
+
+	return containerIdx, containerIdx != -1
+}
+
+// Original source: https://github.com/kubernetes/kubectl/blob/release-1.22/pkg/cmd/set/helper.go#L125-L157
+// Copyright 2016 The Kubernetes Authors. Licensed under the Apache License, Version 2.0.
+
+func findEnv(env []v1.EnvVar, name string) (v1.EnvVar, bool) {
+	for _, e := range env {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return v1.EnvVar{}, false
+}
+
+// updateEnv adds and deletes specified environment variables from existing environment variables.
+// An added variable replaces all existing variables with the same name.
+// Removing a variable removes all existing variables with the same name.
+// If the existing list contains duplicates that are unrelated to the variables being added and removed,
+// those duplicates are left intact in the result.
+// If a variable is both added and removed, the removal takes precedence.
+func updateEnv(existing []v1.EnvVar, env []v1.EnvVar, remove []string) []v1.EnvVar {
+	out := []v1.EnvVar{}
+	covered := sets.NewString(remove...)
+	for _, e := range existing {
+		if covered.Has(e.Name) {
+			continue
+		}
+		newer, ok := findEnv(env, e.Name)
+		if ok {
+			covered.Insert(e.Name)
+			out = append(out, newer)
+			continue
+		}
+		out = append(out, e)
+	}
+	for _, e := range env {
+		if covered.Has(e.Name) {
+			continue
+		}
+		covered.Insert(e.Name)
+		out = append(out, e)
+	}
+	return out
+}

--- a/tests/e2e/slack_test.go
+++ b/tests/e2e/slack_test.go
@@ -1,0 +1,366 @@
+//go:build integration
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vrischmann/envconfig"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/infracloudio/botkube/pkg/filterengine/filters"
+)
+
+type Config struct {
+	KubeconfigPath string `envconfig:"optional,KUBECONFIG"`
+	Deployment     struct {
+		Name          string        `envconfig:"default=botkube"`
+		Namespace     string        `envconfig:"default=botkube"`
+		ContainerName string        `envconfig:"default=botkube"`
+		WaitTimeout   time.Duration `envconfig:"default=3m"`
+		Envs          struct {
+			SlackEnabledName   string `envconfig:"default=COMMUNICATIONS_SLACK_ENABLED"`
+			SlackChannelIDName string `envconfig:"default=COMMUNICATIONS_SLACK_CHANNEL"`
+		}
+	}
+	ClusterName string `envconfig:"default=sample"`
+	Slack       SlackConfig
+}
+
+type SlackConfig struct {
+	BotName                  string `envconfig:"default=botkube"`
+	AdditionalContextMessage string `envconfig:"optional"`
+	TesterAppToken           string
+	MessageWaitTimeout       time.Duration `envconfig:"default=10s"`
+}
+
+const (
+	channelNamePrefix = "test"
+	welcomeText       = "Let the tests begin 🤞"
+	pollInterval      = time.Second
+)
+
+func TestSlack(t *testing.T) {
+	t.Log("Loading configuration...")
+	var appCfg Config
+	err := envconfig.Init(&appCfg)
+	require.NoError(t, err)
+
+	t.Log("Creating Slack API client with provided token...")
+	slackTester, err := newSlackTester(appCfg.Slack)
+	require.NoError(t, err)
+
+	t.Log("Creating K8s client...")
+	k8sConfig, err := clientcmd.BuildConfigFromFlags("", appCfg.KubeconfigPath)
+	require.NoError(t, err)
+	k8sCli, err := kubernetes.NewForConfig(k8sConfig)
+	require.NoError(t, err)
+
+	t.Log("Setting up test Slack setup...")
+	channel, cleanupChannelFn := slackTester.CreateChannel(t)
+	defer cleanupChannelFn(t)
+	slackTester.PostInitialMessage(t, channel.Name)
+	botUserID := slackTester.FindUserIDForBot(t)
+	slackTester.InviteBotToChannel(t, botUserID, channel.ID)
+
+	t.Log("Patching Deployment with test env variables...")
+	deployNsCli := k8sCli.AppsV1().Deployments(appCfg.Deployment.Namespace)
+	revertDeployFn := setTestEnvsForDeploy(t, appCfg, deployNsCli, channel.Name)
+	defer revertDeployFn(t)
+
+	t.Log("Waiting for Deployment")
+	err = waitForDeploymentReady(deployNsCli, appCfg.Deployment.Name, appCfg.Deployment.WaitTimeout)
+	require.NoError(t, err)
+
+	t.Log("Waiting for Bot message on channel...")
+	err = slackTester.WaitForMessagePostedRecentlyEqual(botUserID, channel.ID, fmt.Sprintf("...and now my watch begins for cluster '%s'! :crossed_swords:", appCfg.ClusterName))
+	require.NoError(t, err)
+
+	t.Log("Running actual test cases")
+
+	t.Run("Ping", func(t *testing.T) {
+		command := "ping"
+		expectedMessage := fmt.Sprintf("pong from cluster '%s'", appCfg.ClusterName)
+
+		slackTester.PostMessageToBot(t, channel.Name, command)
+		err := slackTester.WaitForLastMessageContains(botUserID, channel.ID, expectedMessage)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Filters list", func(t *testing.T) {
+		command := "filters list"
+		expectedMessage := codeBlock(heredoc.Doc(`
+			FILTER                  ENABLED DESCRIPTION
+			ImageTagChecker         true    Checks and adds recommendation if 'latest' image tag is used for container image.
+			IngressValidator        true    Checks if services and tls secrets used in ingress specs are available.
+			NamespaceChecker        true    Checks if event belongs to blocklisted namespaces and filter them.
+			NodeEventsChecker       true    Sends notifications on node level critical events.
+			ObjectAnnotationChecker true    Checks if annotations <http://botkube.io/*|botkube.io/*> present in object specs and filters them.
+			PodLabelChecker         true    Checks and adds recommendations if labels are missing in the pod specs.`))
+
+		slackTester.PostMessageToBot(t, channel.Name, command)
+		err := slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Commands list", func(t *testing.T) {
+		command := "commands list"
+		expectedMessage := codeBlock(heredoc.Doc(`
+			allowed verbs:
+			  - api-resources
+			  - api-versions
+			  - auth
+			  - cluster-info
+			  - describe
+			  - diff
+			  - explain
+			  - get
+			  - logs
+			  - top
+			allowed resources:
+			  - configmaps
+			  - daemonsets
+			  - deployments
+			  - namespaces
+			  - nodes
+			  - pods
+			  - statefulsets
+			  - storageclasses`))
+
+		t.Run("With default cluster", func(t *testing.T) {
+			slackTester.PostMessageToBot(t, channel.Name, command)
+			err := slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+			assert.NoError(t, err)
+		})
+
+		t.Run("With custom cluster name", func(t *testing.T) {
+			command := fmt.Sprintf("commands list --cluster-name %s", appCfg.ClusterName)
+
+			slackTester.PostMessageToBot(t, channel.Name, command)
+			err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+			assert.NoError(t, err)
+		})
+
+		t.Run("With unknown cluster name", func(t *testing.T) {
+			command := "commands list --cluster-name non-existing"
+			expectedMessage := codeBlock("Sorry, the admin hasn't configured me to do that for the cluster 'non-existing'.")
+
+			slackTester.PostMessageToBot(t, channel.Name, command)
+			err := slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("Executor", func(t *testing.T) {
+		t.Run("Get Deployment", func(t *testing.T) {
+			command := fmt.Sprintf("get deploy -n %s %s", appCfg.Deployment.Namespace, appCfg.Deployment.Name)
+			assertionFn := func(msg slack.Message) bool {
+				return strings.Contains(msg.Text, heredoc.Doc(fmt.Sprintf("Cluster: %s", appCfg.ClusterName))) &&
+					strings.Contains(msg.Text, "botkube")
+			}
+
+			slackTester.PostMessageToBot(t, channel.Name, command)
+			err = slackTester.WaitForMessagePosted(botUserID, channel.ID, 1, assertionFn)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Get Configmap", func(t *testing.T) {
+			command := fmt.Sprintf("get configmap -n %s", appCfg.Deployment.Namespace)
+			assertionFn := func(msg slack.Message) bool {
+				return strings.Contains(msg.Text, heredoc.Doc(fmt.Sprintf("Cluster: %s", appCfg.ClusterName))) &&
+					strings.Contains(msg.Text, "kube-root-ca.crt") &&
+					strings.Contains(msg.Text, "botkube-configmap")
+			}
+
+			slackTester.PostMessageToBot(t, channel.Name, command)
+			err = slackTester.WaitForMessagePosted(botUserID, channel.ID, 1, assertionFn)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Get forbidden resource", func(t *testing.T) {
+			command := "get ingress"
+			expectedMessage := codeBlock("Command not supported. Please run /botkubehelp to see supported commands.")
+
+			slackTester.PostMessageToBot(t, channel.Name, command)
+			err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Specify unknown command", func(t *testing.T) {
+			command := "unknown"
+			expectedMessage := codeBlock("Command not supported. Please run /botkubehelp to see supported commands.")
+
+			slackTester.PostMessageToBot(t, channel.Name, command)
+			err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+			assert.NoError(t, err)
+		})
+
+		t.Run("Specify invalid command", func(t *testing.T) {
+			command := "get"
+			expectedMessage := codeBlock("Command not supported. Please run /botkubehelp to see supported commands.")
+
+			slackTester.PostMessageToBot(t, channel.Name, command)
+			err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("Notifications", func(t *testing.T) {
+		cfgMapCli := k8sCli.CoreV1().ConfigMaps(appCfg.Deployment.Namespace)
+
+		t.Log("Creating ConfigMap...")
+		var cfgMapAlreadyDeleted bool
+		cfgMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      channel.Name,
+				Namespace: appCfg.Deployment.Namespace,
+			},
+		}
+		cfgMap, err = cfgMapCli.Create(context.Background(), cfgMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		defer cleanupCreatedCfgMapIfShould(t, cfgMapCli, cfgMap.Name, &cfgMapAlreadyDeleted)
+
+		t.Log("Expecting bot message...")
+		assertionFn := func(msg slack.Message) bool {
+			return doesMessageContainExactlyOneAttachment(
+				msg,
+				"v1/configmaps created",
+				"2eb886",
+				fmt.Sprintf("ConfigMap *%s/%s* has been created in *%s* cluster", cfgMap.Namespace, cfgMap.Name, appCfg.ClusterName),
+			)
+		}
+		err = slackTester.WaitForMessagePosted(botUserID, channel.ID, 1, assertionFn)
+		require.NoError(t, err)
+
+		t.Log("Updating ConfigMap...")
+		cfgMap.Data = map[string]string{
+			"operation": "update",
+		}
+		cfgMap, err = cfgMapCli.Update(context.Background(), cfgMap, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		t.Log("Expecting bot message...")
+		assertionFn = func(msg slack.Message) bool {
+			return doesMessageContainExactlyOneAttachment(
+				msg,
+				"v1/configmaps updated",
+				"daa038",
+				fmt.Sprintf("ConfigMap *%s/%s* has been updated in *%s* cluster", cfgMap.Namespace, cfgMap.Name, appCfg.ClusterName),
+			)
+		}
+		err = slackTester.WaitForMessagePosted(botUserID, channel.ID, 1, assertionFn)
+		require.NoError(t, err)
+
+		t.Log("Stopping notifier...")
+		command := "notifier stop"
+		expectedMessage := codeBlock(fmt.Sprintf("Sure! I won't send you notifications from cluster '%s' anymore.", appCfg.ClusterName))
+
+		slackTester.PostMessageToBot(t, channel.Name, command)
+		err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+		assert.NoError(t, err)
+
+		t.Log("Updating ConfigMap once again...")
+		cfgMap.Data = map[string]string{
+			"operation": "update-second",
+		}
+		_, err = cfgMapCli.Update(context.Background(), cfgMap, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		t.Log("Ensuring bot didn't write anything new...")
+		time.Sleep(appCfg.Slack.MessageWaitTimeout)
+		// Same expected message as before
+		err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+		require.NoError(t, err)
+
+		t.Log("Starting notifier")
+		command = "notifier start"
+		expectedMessage = codeBlock(fmt.Sprintf("Brace yourselves, notifications are coming from cluster '%s'.", appCfg.ClusterName))
+
+		slackTester.PostMessageToBot(t, channel.Name, command)
+		err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+
+		t.Log("Creating and deleting ignored ConfigMap")
+		ignoredCfgMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-ignored", channel.Name),
+				Namespace: appCfg.Deployment.Namespace,
+				Annotations: map[string]string{
+					filters.DisableAnnotation: "true",
+				},
+			},
+		}
+		_, err = cfgMapCli.Create(context.Background(), ignoredCfgMap, metav1.CreateOptions{})
+		require.NoError(t, err)
+		err = cfgMapCli.Delete(context.Background(), ignoredCfgMap.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+
+		t.Log("Ensuring bot didn't write anything new...")
+		time.Sleep(appCfg.Slack.MessageWaitTimeout)
+		err = slackTester.WaitForLastMessageEqual(botUserID, channel.ID, expectedMessage)
+		require.NoError(t, err)
+
+		t.Log("Deleting ConfigMap")
+		err = cfgMapCli.Delete(context.Background(), cfgMap.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+		cfgMapAlreadyDeleted = true
+
+		t.Log("Expecting bot message...")
+		assertionFn = func(msg slack.Message) bool {
+			return doesMessageContainExactlyOneAttachment(
+				msg,
+				"v1/configmaps deleted",
+				"a30200",
+				fmt.Sprintf("ConfigMap *%s/%s* has been deleted in *%s* cluster", cfgMap.Namespace, cfgMap.Name, appCfg.ClusterName),
+			)
+		}
+		err = slackTester.WaitForMessagePosted(botUserID, channel.ID, 1, assertionFn)
+		require.NoError(t, err)
+	})
+}
+
+func codeBlock(in string) string {
+	return fmt.Sprintf("```\n%s\n```", in)
+}
+
+func doesMessageContainExactlyOneAttachment(msg slack.Message, expectedTitle, expectedColor, expectedFieldMessage string) bool {
+	if len(msg.Attachments) != 1 {
+		return false
+	}
+
+	attachment := msg.Attachments[0]
+	title := attachment.Title
+	color := attachment.Color
+
+	if len(attachment.Fields) != 1 {
+		return false
+	}
+
+	fieldMessage := attachment.Fields[0].Value
+
+	return title == expectedTitle &&
+		color == expectedColor &&
+		fieldMessage == expectedFieldMessage
+}
+
+func cleanupCreatedCfgMapIfShould(t *testing.T, cfgMapCli corev1.ConfigMapInterface, name string, cfgMapAlreadyDeleted *bool) {
+	if cfgMapAlreadyDeleted != nil && *cfgMapAlreadyDeleted {
+		return
+	}
+
+	t.Log("Cleaning up created ConfigMap...")
+	err := cfgMapCli.Delete(context.Background(), name, metav1.DeleteOptions{})
+	assert.NoError(t, err)
+}

--- a/tests/e2e/slack_test.go
+++ b/tests/e2e/slack_test.go
@@ -71,7 +71,8 @@ func TestSlack(t *testing.T) {
 
 	t.Log("Setting up test Slack setup...")
 	channel, cleanupChannelFn := slackTester.CreateChannel(t)
-	defer cleanupChannelFn(t)
+	t.Cleanup(func() { cleanupChannelFn(t) })
+
 	slackTester.PostInitialMessage(t, channel.Name)
 	botUserID := slackTester.FindUserIDForBot(t)
 	slackTester.InviteBotToChannel(t, botUserID, channel.ID)
@@ -79,7 +80,7 @@ func TestSlack(t *testing.T) {
 	t.Log("Patching Deployment with test env variables...")
 	deployNsCli := k8sCli.AppsV1().Deployments(appCfg.Deployment.Namespace)
 	revertDeployFn := setTestEnvsForDeploy(t, appCfg, deployNsCli, channel.Name)
-	defer revertDeployFn(t)
+	t.Cleanup(func() { revertDeployFn(t) })
 
 	t.Log("Waiting for Deployment")
 	err = waitForDeploymentReady(deployNsCli, appCfg.Deployment.Name, appCfg.Deployment.WaitTimeout)
@@ -232,7 +233,7 @@ func TestSlack(t *testing.T) {
 		cfgMap, err = cfgMapCli.Create(context.Background(), cfgMap, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		defer cleanupCreatedCfgMapIfShould(t, cfgMapCli, cfgMap.Name, &cfgMapAlreadyDeleted)
+		t.Cleanup(func() { cleanupCreatedCfgMapIfShould(t, cfgMapCli, cfgMap.Name, &cfgMapAlreadyDeleted) })
 
 		t.Log("Expecting bot message...")
 		assertionFn := func(msg slack.Message) bool {
@@ -349,7 +350,7 @@ func TestSlack(t *testing.T) {
 		pod, err = podCli.Create(context.Background(), pod, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		defer cleanupCreatedPod(t, podCli, pod.Name)
+		t.Cleanup(func() { cleanupCreatedPod(t, podCli, pod.Name) })
 
 		t.Log("Expecting bot message...")
 		assertionFn := func(msg slack.Message) bool {

--- a/tests/e2e/slack_tester_test.go
+++ b/tests/e2e/slack_tester_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const recentMessagesLimit = 5
+
+type slackTester struct {
+	cli *slack.Client
+	cfg SlackConfig
+}
+
+func newSlackTester(slackCfg SlackConfig) (*slackTester, error) {
+	slackCli := slack.New(slackCfg.TesterAppToken)
+	_, err := slackCli.AuthTest()
+	if err != nil {
+		return nil, err
+	}
+
+	return &slackTester{cli: slackCli, cfg: slackCfg}, nil
+}
+
+func (s *slackTester) CreateChannel(t *testing.T) (*slack.Channel, func(t *testing.T)) {
+	t.Helper()
+	randomID := uuid.New()
+	channelName := fmt.Sprintf("%s-%s", channelNamePrefix, randomID.String())
+
+	t.Logf("Creating channel %q...", channelName)
+	// > There’s no limit to how many unique channels you can have in Slack — go ahead, create as many as you’d like!
+	// Sure, thanks Slack!
+	// Source: https://slack.com/help/articles/201402297-Create-a-channel
+	channel, err := s.cli.CreateConversation(channelName, false)
+	require.NoError(t, err)
+
+	t.Logf("Channel %q (ID: %q) created", channelName, channel.ID)
+
+	cleanupFn := func(t *testing.T) {
+		t.Helper()
+		t.Logf("Archiving channel %q...", channel.Name)
+		// We cannot delete channel: https://stackoverflow.com/questions/46807744/delete-channel-in-slack-api
+		err = s.cli.ArchiveConversation(channel.ID)
+		assert.NoError(t, err)
+	}
+
+	return channel, cleanupFn
+}
+
+func (s *slackTester) PostInitialMessage(t *testing.T, channelName string) {
+	t.Helper()
+	t.Log("Posting welcome message...")
+
+	var additionalContextMsg string
+	if s.cfg.AdditionalContextMessage != "" {
+		additionalContextMsg = fmt.Sprintf("%s\n", s.cfg.AdditionalContextMessage)
+	}
+	message := fmt.Sprintf("Hello!\n%s%s", additionalContextMsg, welcomeText)
+	_, _, err := s.cli.PostMessage(channelName, slack.MsgOptionText(message, false))
+	require.NoError(t, err)
+}
+
+func (s *slackTester) PostMessageToBot(t *testing.T, channelName, command string) {
+	message := fmt.Sprintf("<@%s> %s", s.cfg.BotName, command)
+	_, _, err := s.cli.PostMessage(channelName, slack.MsgOptionText(message, false))
+	require.NoError(t, err)
+}
+
+func (s *slackTester) FindUserIDForBot(t *testing.T) string {
+	t.Log("Getting users...")
+	res, err := s.cli.GetUsers()
+	require.NoError(t, err)
+
+	t.Logf("Finding user ID by name %q...", s.cfg.BotName)
+	var userID string
+	for _, u := range res {
+		if u.Name != s.cfg.BotName {
+			continue
+		}
+		userID = u.ID
+		break
+	}
+
+	return userID
+}
+
+func (s *slackTester) InviteBotToChannel(t *testing.T, botID, channelID string) {
+	t.Logf("Inviting bot with ID %q to the channel with ID %q", botID, channelID)
+	_, err := s.cli.InviteUsersToConversation(channelID, botID)
+	require.NoError(t, err)
+}
+
+func (s *slackTester) WaitForMessagePostedRecentlyEqual(userID, channelID string, expectedMsg string) error {
+	return s.WaitForMessagePosted(userID, channelID, recentMessagesLimit, func(msg slack.Message) bool {
+		return strings.EqualFold(msg.Text, expectedMsg)
+	})
+}
+
+func (s *slackTester) WaitForLastMessageContains(userID, channelID string, expectedMsgSubstring string) error {
+	return s.WaitForMessagePosted(userID, channelID, 1, func(msg slack.Message) bool {
+		return strings.Contains(msg.Text, expectedMsgSubstring)
+	})
+}
+
+func (s *slackTester) WaitForLastMessageEqual(userID, channelID string, expectedMsg string) error {
+	return s.WaitForMessagePosted(userID, channelID, 1, func(msg slack.Message) bool {
+		return msg.Text == expectedMsg
+	})
+}
+
+func (s *slackTester) WaitForMessagePosted(userID, channelID string, limitMessages int, msgAssertFn func(msg slack.Message) bool) error {
+	var fetchedMessages []slack.Message
+	var lastErr error
+	err := wait.Poll(pollInterval, s.cfg.MessageWaitTimeout, func() (done bool, err error) {
+		historyRes, err := s.cli.GetConversationHistory(&slack.GetConversationHistoryParameters{
+			ChannelID: channelID, Limit: limitMessages,
+		})
+		if err != nil {
+			lastErr = err
+			return false, nil
+		}
+
+		fetchedMessages = historyRes.Messages
+		for _, msg := range historyRes.Messages {
+			if msg.User != userID {
+				continue
+			}
+
+			if !msgAssertFn(msg) {
+				// different message
+				continue
+			}
+
+			return true, nil
+		}
+
+		return false, nil
+	})
+	if lastErr == nil {
+		lastErr = errors.New("message assertion function returned false")
+	}
+	if err != nil {
+		if err == wait.ErrWaitTimeout {
+			return fmt.Errorf("while waiting for condition: last error: %w; fetched messages: %+v", lastErr, fetchedMessages)
+		}
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY

- Implement E2E tests against BotKube deployed on K8s and real Slack API
- Allow building Docker image
- Ensure output from FilterEngine and Executor are predictable (same order every map iteration)
- Change missing TLS secret from Recommendation to Warning
- Add happy path unit test for Ingress validation filter (to make sure we will be able to remove current E2E tests with fake Slack and K8s in near future as the coverage is equal or higher)

This PR will be followed-up by a dedicated PR which run these tests on CI (with `helm test`).

See https://github.com/infracloudio/botkube/issues/615

##### TESTING

1. Check out this PR
1. See the testing instruction in the `./tests` package.